### PR TITLE
Improve test coverage across multiple packages

### DIFF
--- a/css/values_test.go
+++ b/css/values_test.go
@@ -59,3 +59,108 @@ func TestBaseFontHeight(t *testing.T) {
 		t.Errorf("BaseFontHeight = %v, expected 13.0", BaseFontHeight)
 	}
 }
+
+func TestParseColor(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		r, g, b  uint8
+	}{
+		// CSS 2.1 basic named colors
+		{"black", "black", 0, 0, 0},
+		{"white", "white", 255, 255, 255},
+		{"red", "red", 255, 0, 0},
+		{"green", "green", 0, 128, 0},
+		{"blue", "blue", 0, 0, 255},
+		{"yellow", "yellow", 255, 255, 0},
+		{"navy", "navy", 0, 0, 128},
+		{"purple", "purple", 128, 0, 128},
+		{"silver", "silver", 192, 192, 192},
+		{"gray", "gray", 128, 128, 128},
+		{"grey", "grey", 128, 128, 128},
+		{"maroon", "maroon", 128, 0, 0},
+		{"olive", "olive", 128, 128, 0},
+		{"teal", "teal", 0, 128, 128},
+		{"lime", "lime", 0, 255, 0},
+		{"orange", "orange", 255, 165, 0},
+		{"fuchsia", "fuchsia", 255, 0, 255},
+		{"magenta", "magenta", 255, 0, 255},
+		{"aqua", "aqua", 0, 255, 255},
+		{"cyan", "cyan", 0, 255, 255},
+		// Extended colors
+		{"lightgray", "lightgray", 211, 211, 211},
+		{"lightgrey", "lightgrey", 211, 211, 211},
+		{"darkgray", "darkgray", 169, 169, 169},
+		{"darkgreen", "darkgreen", 0, 100, 0},
+		{"pink", "pink", 255, 192, 203},
+		{"gold", "gold", 255, 215, 0},
+		{"brown", "brown", 165, 42, 42},
+		{"coral", "coral", 255, 127, 80},
+		{"crimson", "crimson", 220, 20, 60},
+		{"indigo", "indigo", 75, 0, 130},
+		// Case insensitivity
+		{"uppercase RED", "RED", 255, 0, 0},
+		{"mixed Blue", "Blue", 0, 0, 255},
+		// Hex colors - 6 digit
+		{"#FF0000", "#FF0000", 255, 0, 0},
+		{"#00FF00", "#00FF00", 0, 255, 0},
+		{"#0000FF", "#0000FF", 0, 0, 255},
+		{"#FFFFFF", "#FFFFFF", 255, 255, 255},
+		{"#000000", "#000000", 0, 0, 0},
+		{"#2196F3", "#2196F3", 33, 150, 243},
+		// Hex colors - 3 digit shorthand
+		{"#f00", "#f00", 255, 0, 0},
+		{"#0f0", "#0f0", 0, 255, 0},
+		{"#00f", "#00f", 0, 0, 255},
+		{"#fff", "#fff", 255, 255, 255},
+		{"#000", "#000", 0, 0, 0},
+		// Unknown defaults to black
+		{"unknown", "unknown", 0, 0, 0},
+		{"empty", "", 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseColor(tt.input)
+			if result.R != tt.r || result.G != tt.g || result.B != tt.b {
+				t.Errorf("ParseColor(%q) = {R:%d,G:%d,B:%d}, expected {R:%d,G:%d,B:%d}",
+					tt.input, result.R, result.G, result.B, tt.r, tt.g, tt.b)
+			}
+			if result.A != 255 {
+				t.Errorf("ParseColor(%q) alpha = %d, expected 255", tt.input, result.A)
+			}
+		})
+	}
+}
+
+func TestParseHexColor(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		r, g, b uint8
+	}{
+		{"6-digit red", "#FF0000", 255, 0, 0},
+		{"6-digit green", "#00FF00", 0, 255, 0},
+		{"6-digit blue", "#0000FF", 0, 0, 255},
+		{"6-digit mixed", "#4CAF50", 76, 175, 80},
+		{"3-digit red", "#f00", 255, 0, 0},
+		{"3-digit green", "#0f0", 0, 255, 0},
+		{"3-digit blue", "#00f", 0, 0, 255},
+		{"3-digit white", "#fff", 255, 255, 255},
+		{"3-digit black", "#000", 0, 0, 0},
+		{"3-digit gray", "#999", 153, 153, 153},
+		// Invalid length returns zero color
+		{"invalid length", "#1234", 0, 0, 0},
+		{"empty after #", "#", 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseHexColor(tt.input)
+			if result.R != tt.r || result.G != tt.g || result.B != tt.b {
+				t.Errorf("parseHexColor(%q) = {R:%d,G:%d,B:%d}, expected {R:%d,G:%d,B:%d}",
+					tt.input, result.R, result.G, result.B, tt.r, tt.g, tt.b)
+			}
+		})
+	}
+}

--- a/dom/loader_test.go
+++ b/dom/loader_test.go
@@ -99,3 +99,57 @@ func TestIsDataURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"http://example.com/image.png", true},
+		{"https://example.com/image.png", true},
+		{"http://localhost:8080/file", true},
+		{"data:text/plain;base64,SGVsbG8=", false},
+		{"/path/to/file.png", false},
+		{"relative/path.png", false},
+		{"", false},
+		{"ftp://example.com/file", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isURL(tt.input); got != tt.want {
+				t.Errorf("isURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadResourceAsString(t *testing.T) {
+	loader := NewResourceLoader("")
+
+	result, err := loader.LoadResourceAsString("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==")
+	if err != nil {
+		t.Fatalf("LoadResourceAsString() failed: %v", err)
+	}
+	if result != "Hello, World!" {
+		t.Errorf("LoadResourceAsString() = %q, want %q", result, "Hello, World!")
+	}
+}
+
+func TestLoadResourceAsString_Error(t *testing.T) {
+	loader := NewResourceLoader("")
+
+	_, err := loader.LoadResourceAsString("data:text/plain;base64,!!!invalid!!!")
+	if err == nil {
+		t.Error("LoadResourceAsString() expected error for invalid base64, got nil")
+	}
+}
+
+func TestLoadResource_FileNotFound(t *testing.T) {
+	loader := NewResourceLoader("")
+
+	_, err := loader.LoadResource("/nonexistent/path/to/file.txt")
+	if err == nil {
+		t.Error("LoadResource() expected error for nonexistent file, got nil")
+	}
+}

--- a/dom/url_test.go
+++ b/dom/url_test.go
@@ -96,3 +96,117 @@ func TestResolveURLsNonImgElements(t *testing.T) {
 		t.Errorf("expected data-src=test.png, got %s", div.GetAttribute("data-src"))
 	}
 }
+
+func TestResolveURLsLinkElement(t *testing.T) {
+	doc := NewDocument()
+	link := NewElement("link")
+	link.SetAttribute("rel", "stylesheet")
+	link.SetAttribute("href", "style.css")
+	doc.AppendChild(link)
+
+	ResolveURLs(doc, "/var/www")
+
+	expected := filepath.Join("/var/www", "style.css")
+	if link.GetAttribute("href") != expected {
+		t.Errorf("expected href=%s, got %s", expected, link.GetAttribute("href"))
+	}
+}
+
+func TestResolveURLString(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseURL     string
+		relativeURL string
+		expected    string
+	}{
+		{
+			name:        "data URL passthrough",
+			baseURL:     "/home/test",
+			relativeURL: "data:text/plain;base64,SGVsbG8=",
+			expected:    "data:text/plain;base64,SGVsbG8=",
+		},
+		{
+			name:        "absolute http URL passthrough",
+			baseURL:     "/home/test",
+			relativeURL: "http://example.com/image.png",
+			expected:    "http://example.com/image.png",
+		},
+		{
+			name:        "absolute https URL passthrough",
+			baseURL:     "/home/test",
+			relativeURL: "https://example.com/style.css",
+			expected:    "https://example.com/style.css",
+		},
+		{
+			name:        "relative path with file base",
+			baseURL:     "/home/test",
+			relativeURL: "image.png",
+			expected:    filepath.Join("/home/test", "image.png"),
+		},
+		{
+			name:        "relative path with subdirectory",
+			baseURL:     "/var/www",
+			relativeURL: "images/logo.png",
+			expected:    filepath.Join("/var/www", "images/logo.png"),
+		},
+		{
+			name:        "HTTP base with relative URL",
+			baseURL:     "http://example.com/page/",
+			relativeURL: "image.png",
+			expected:    "http://example.com/page/image.png",
+		},
+		{
+			name:        "HTTPS base with relative URL",
+			baseURL:     "https://example.com/",
+			relativeURL: "style.css",
+			expected:    "https://example.com/style.css",
+		},
+		{
+			name:        "HTTP base with path traversal",
+			baseURL:     "http://example.com/dir/page.html",
+			relativeURL: "../images/logo.png",
+			expected:    "http://example.com/images/logo.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveURLString(tt.baseURL, tt.relativeURL)
+			if result != tt.expected {
+				t.Errorf("ResolveURLString(%q, %q) = %q, want %q",
+					tt.baseURL, tt.relativeURL, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFetchExternalStylesheets(t *testing.T) {
+	// Test with no link elements
+	doc := NewDocument()
+	body := NewElement("body")
+	doc.AppendChild(body)
+
+	result := FetchExternalStylesheets(doc)
+	if result != "" {
+		t.Errorf("FetchExternalStylesheets() with no links = %q, want %q", result, "")
+	}
+}
+
+func TestFetchExternalStylesheets_NonStylesheet(t *testing.T) {
+	// Test with a link element that is not a stylesheet
+	doc := NewDocument()
+	link := NewElement("link")
+	link.SetAttribute("rel", "icon")
+	link.SetAttribute("href", "favicon.ico")
+	doc.AppendChild(link)
+
+	result := FetchExternalStylesheets(doc)
+	if result != "" {
+		t.Errorf("FetchExternalStylesheets() with non-stylesheet link = %q, want empty", result)
+	}
+}
+
+func TestResolveURLs_NilNode(t *testing.T) {
+	// Should not panic on nil node
+	ResolveURLs(nil, "/home/test")
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -113,3 +113,151 @@ func TestSetPrefix(t *testing.T) {
 	// Reset prefix
 	SetPrefix("")
 }
+
+func TestNewLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf, DebugLevel)
+
+	logger.Debug("debug from new logger")
+	logger.Info("info from new logger")
+	logger.Warn("warn from new logger")
+	logger.Error("error from new logger")
+
+	output := buf.String()
+
+	if !strings.Contains(output, "[DEBUG]") {
+		t.Error("Expected [DEBUG] in output")
+	}
+	if !strings.Contains(output, "[INFO]") {
+		t.Error("Expected [INFO] in output")
+	}
+	if !strings.Contains(output, "[WARN]") {
+		t.Error("Expected [WARN] in output")
+	}
+	if !strings.Contains(output, "[ERROR]") {
+		t.Error("Expected [ERROR] in output")
+	}
+}
+
+func TestLoggerFormatted(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf, DebugLevel)
+
+	logger.Debugf("debug %s %d", "value", 1)
+	logger.Infof("info %s %d", "value", 2)
+	logger.Warnf("warn %s %d", "value", 3)
+	logger.Errorf("error %s %d", "value", 4)
+
+	output := buf.String()
+
+	if !strings.Contains(output, "debug value 1") {
+		t.Errorf("Expected formatted debug message, got: %s", output)
+	}
+	if !strings.Contains(output, "info value 2") {
+		t.Errorf("Expected formatted info message, got: %s", output)
+	}
+	if !strings.Contains(output, "warn value 3") {
+		t.Errorf("Expected formatted warn message, got: %s", output)
+	}
+	if !strings.Contains(output, "error value 4") {
+		t.Errorf("Expected formatted error message, got: %s", output)
+	}
+}
+
+func TestLoggerWithFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf, InfoLevel)
+
+	logger.WithFields(InfoLevel, "test message", map[string]interface{}{
+		"key": "value",
+		"num": 42,
+	})
+
+	output := buf.String()
+
+	if !strings.Contains(output, "test message") {
+		t.Error("Expected test message in output")
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Error("Expected key=value in output")
+	}
+}
+
+func TestLoggerLevelFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf, ErrorLevel)
+
+	logger.Debug("debug")
+	logger.Info("info")
+	logger.Warn("warn")
+	logger.Error("error")
+
+	output := buf.String()
+
+	if strings.Contains(output, "[DEBUG]") || strings.Contains(output, "[INFO]") || strings.Contains(output, "[WARN]") {
+		t.Error("Expected only ERROR level output")
+	}
+	if !strings.Contains(output, "[ERROR]") {
+		t.Error("Expected [ERROR] in output")
+	}
+}
+
+func TestGetLevel(t *testing.T) {
+	SetLevel(DebugLevel)
+	if GetLevel() != DebugLevel {
+		t.Errorf("GetLevel() = %v, want %v", GetLevel(), DebugLevel)
+	}
+
+	SetLevel(ErrorLevel)
+	if GetLevel() != ErrorLevel {
+		t.Errorf("GetLevel() = %v, want %v", GetLevel(), ErrorLevel)
+	}
+
+	// Reset to default
+	SetLevel(WarnLevel)
+}
+
+func TestLevelString(t *testing.T) {
+	tests := []struct {
+		level    Level
+		expected string
+	}{
+		{DebugLevel, "DEBUG"},
+		{InfoLevel, "INFO"},
+		{WarnLevel, "WARN"},
+		{ErrorLevel, "ERROR"},
+		{Level(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		if tt.level.String() != tt.expected {
+			t.Errorf("Level(%d).String() = %q, want %q", tt.level, tt.level.String(), tt.expected)
+		}
+	}
+}
+
+func TestGlobalWarnf(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(WarnLevel)
+
+	Warnf("warning %s", "message")
+
+	output := buf.String()
+	if !strings.Contains(output, "warning message") {
+		t.Errorf("Expected formatted warn message, got: %s", output)
+	}
+}
+
+func TestGlobalErrorf(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(ErrorLevel)
+
+	Errorf("error %d", 42)
+
+	output := buf.String()
+	if !strings.Contains(output, "error 42") {
+		t.Errorf("Expected formatted error message, got: %s", output)
+	}
+}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -881,3 +881,32 @@ func TestExtractURLFromCSS(t *testing.T) {
 		})
 	}
 }
+
+func TestCollapseWhitespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"single word", "hello", "hello"},
+		{"multiple spaces", "hello   world", "hello world"},
+		{"leading spaces", "   hello", "hello"},
+		{"trailing spaces", "hello   ", "hello"},
+		{"tabs", "hello\tworld", "hello world"},
+		{"newlines", "hello\nworld", "hello world"},
+		{"carriage returns", "hello\rworld", "hello world"},
+		{"mixed whitespace", "hello \t\n world", "hello world"},
+		{"only spaces", "   ", ""},
+		{"multiple words", "  hello   world  foo  ", "hello world foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := collapseWhitespace(tt.input)
+			if result != tt.expected {
+				t.Errorf("collapseWhitespace(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/style/style_test.go
+++ b/style/style_test.go
@@ -1123,3 +1123,190 @@ func TestInlineStyleSpecificity(t *testing.T) {
 		t.Errorf("Expected inline style 'red' to win, got %v", divStyled.Styles["color"])
 	}
 }
+
+func TestPresentationalHints_Width(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *dom.Node
+		expected map[string]string
+	}{
+		{
+			name: "width as pixels",
+			node: func() *dom.Node {
+				n := dom.NewElement("table")
+				n.SetAttribute("width", "500")
+				return n
+			}(),
+			expected: map[string]string{"width": "500px"},
+		},
+		{
+			name: "width as percentage",
+			node: func() *dom.Node {
+				n := dom.NewElement("table")
+				n.SetAttribute("width", "100%")
+				return n
+			}(),
+			expected: map[string]string{"width": "100%"},
+		},
+		{
+			name: "height as pixels",
+			node: func() *dom.Node {
+				n := dom.NewElement("td")
+				n.SetAttribute("height", "50")
+				return n
+			}(),
+			expected: map[string]string{"height": "50px"},
+		},
+		{
+			name: "height as percentage",
+			node: func() *dom.Node {
+				n := dom.NewElement("td")
+				n.SetAttribute("height", "50%")
+				return n
+			}(),
+			expected: map[string]string{"height": "50%"},
+		},
+		{
+			name: "strong element bold",
+			node: dom.NewElement("strong"),
+			expected: map[string]string{"font-weight": "bold"},
+		},
+		{
+			name: "b element bold",
+			node: dom.NewElement("b"),
+			expected: map[string]string{"font-weight": "bold"},
+		},
+		{
+			name: "em element italic",
+			node: dom.NewElement("em"),
+			expected: map[string]string{"font-style": "italic"},
+		},
+		{
+			name: "i element italic",
+			node: dom.NewElement("i"),
+			expected: map[string]string{"font-style": "italic"},
+		},
+		{
+			name: "u element underline",
+			node: dom.NewElement("u"),
+			expected: map[string]string{"text-decoration": "underline"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			styles := make(map[string]string)
+			applyPresentationalHints(tt.node, styles)
+
+			for key, expectedVal := range tt.expected {
+				if actualVal, ok := styles[key]; !ok {
+					t.Errorf("Expected style %s to be set", key)
+				} else if actualVal != expectedVal {
+					t.Errorf("Style %s = %v, expected %v", key, actualVal, expectedVal)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveCSSURLs(t *testing.T) {
+	root := &StyledNode{
+		Styles: map[string]string{
+			"background-image": "url(image.png)",
+			"color":            "red",
+		},
+		Children: []*StyledNode{
+			{
+				Styles: map[string]string{
+					"background": "url(child.png)",
+				},
+				Children: []*StyledNode{},
+			},
+		},
+	}
+
+	ResolveCSSURLs(root, "/var/www")
+
+	// The background-image URL should be resolved
+	bgImage := root.Styles["background-image"]
+	if bgImage == "url(image.png)" {
+		t.Error("Expected background-image URL to be resolved, but it was not")
+	}
+
+	// Non-URL styles should be unchanged
+	if root.Styles["color"] != "red" {
+		t.Errorf("Expected color to remain 'red', got %v", root.Styles["color"])
+	}
+
+	// Child URLs should also be resolved
+	childBg := root.Children[0].Styles["background"]
+	if childBg == "url(child.png)" {
+		t.Error("Expected child background URL to be resolved, but it was not")
+	}
+}
+
+func TestResolveCSSURLs_Nil(t *testing.T) {
+	// Should not panic on nil
+	ResolveCSSURLs(nil, "/var/www")
+}
+
+func TestResolveCSSURLs_NoURLs(t *testing.T) {
+	root := &StyledNode{
+		Styles: map[string]string{
+			"color":      "blue",
+			"font-size":  "14px",
+		},
+		Children: []*StyledNode{},
+	}
+
+	ResolveCSSURLs(root, "/var/www")
+
+	// Styles without URLs should be unchanged
+	if root.Styles["color"] != "blue" {
+		t.Errorf("Expected color to remain 'blue', got %v", root.Styles["color"])
+	}
+}
+
+func TestCellpaddingInheritance(t *testing.T) {
+	// Create a table with cellpadding
+	table := dom.NewElement("table")
+	table.SetAttribute("cellpadding", "5")
+	tr := dom.NewElement("tr")
+	table.AppendChild(tr)
+	td := dom.NewElement("td")
+	tr.AppendChild(td)
+
+	// Style the tree
+	doc := dom.NewDocument()
+	doc.AppendChild(table)
+
+	styledTree := StyleTree(doc, &css.Stylesheet{Rules: []*css.Rule{}})
+
+	// Find the td node in the styled tree
+	tableStyled := styledTree.Children[0]
+	trStyled := tableStyled.Children[0]
+	tdStyled := trStyled.Children[0]
+
+	// The td should have padding applied from cellpadding
+	if tdStyled.Styles["padding-top"] != "5px" {
+		t.Errorf("Expected td padding-top '5px' from cellpadding, got %v", tdStyled.Styles["padding-top"])
+	}
+	if tdStyled.Styles["padding-right"] != "5px" {
+		t.Errorf("Expected td padding-right '5px' from cellpadding, got %v", tdStyled.Styles["padding-right"])
+	}
+}
+
+func TestCellspacingAttribute(t *testing.T) {
+	table := dom.NewElement("table")
+	table.SetAttribute("cellspacing", "3")
+
+	doc := dom.NewDocument()
+	doc.AppendChild(table)
+
+	styledTree := StyleTree(doc, &css.Stylesheet{Rules: []*css.Rule{}})
+
+	tableStyled := styledTree.Children[0]
+	if tableStyled.Styles["border-spacing"] != "3px" {
+		t.Errorf("Expected border-spacing '3px' from cellspacing, got %v", tableStyled.Styles["border-spacing"])
+	}
+}


### PR DESCRIPTION
## Summary

- **css**: Add `ParseColor` and `parseHexColor` tests (74.9% → 81.3%)
- **dom**: Add `isURL`, `LoadResourceAsString`, `ResolveURLString`, `FetchExternalStylesheets` tests (50.9% → 76.3%)
- **log**: Add `New`, `GetLevel`, `LevelString`, all `Logger` methods tests (66.0% → 98.0%)
- **render**: Add `collapseWhitespace` tests (51.8% → 56.7%)
- **style**: Add `ResolveCSSURLs`, width/height hints, `strong`/`em`/`u` presentational hints, `cellpadding`/`cellspacing` tests (68.2% → 90.8%)

## Test plan

- [x] All existing tests continue to pass (`go test ./...`)
- [x] New tests exercise previously uncovered code paths
- [x] No new source code changes — test-only additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)