### PR TITLE
Add emojis to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@
 
 A simple web browser implementation in Go, focusing on static HTML and CSS 2.1 compliance. This project aims to stay close to W3C specifications and provide a clean, well-organized codebase for educational purposes.
 
-## Features
+## ✨ Features
 
-- HTML parsing with DOM tree construction
-- CSS 2.1 parsing and style computation
-- Visual formatting model (box model, block layout)
-- **High-quality text rendering** with Go fonts (proportional sans-serif)
-- Font styling support (bold, italic, underline, size)
-- Image rendering (PNG, JPEG, GIF, SVG support)
-- **Data URLs**: Support for RFC 2397 data URLs (base64 and URL-encoded)
-- Background and border rendering
-- PNG image output
-- **Network support**: Load pages via HTTP/HTTPS
-- **External CSS**: Fetch and apply stylesheets from `<link>` tags
-- **Network images**: Load images from remote URLs
-- **WebAssembly**: Run the browser entirely in a web client
+- 📝 HTML parsing with DOM tree construction
+- 🎨 CSS 2.1 parsing and style computation
+- 📦 Visual formatting model (box model, block layout)
+- 🔤 **High-quality text rendering** with Go fonts (proportional sans-serif)
+- 🎭 Font styling support (bold, italic, underline, size)
+- 🖼️ Image rendering (PNG, JPEG, GIF, SVG support)
+- 📎 **Data URLs**: Support for RFC 2397 data URLs (base64 and URL-encoded)
+- 🖌️ Background and border rendering
+- 📸 PNG image output
+- 🌐 **Network support**: Load pages via HTTP/HTTPS
+- 🔗 **External CSS**: Fetch and apply stylesheets from `<link>` tags
+- 🌍 **Network images**: Load images from remote URLs
+- 🕸️ **WebAssembly**: Run the browser entirely in a web client
 
-## Project Structure
+## 📁 Project Structure
 
 ```
 browser/
@@ -38,7 +38,7 @@ browser/
 └── test/            # Test files and fixtures
 ```
 
-## Specifications
+## 📖 Specifications
 
 This browser implementation follows these W3C specifications:
 
@@ -51,15 +51,15 @@ This browser implementation follows these W3C specifications:
   - [CSS 2.1 §9 Visual Formatting Model](https://www.w3.org/TR/CSS21/visuren.html)
 - **RFC 2397**: The "data" URL scheme for inline resources
 
-## Quick Start
+## 🚀 Quick Start
 
-### Building
+### 🔨 Building
 
 ```bash
 go build ./cmd/browser
 ```
 
-### Running
+### ▶️ Running
 
 ```bash
 # Render local HTML file to PNG
@@ -75,33 +75,33 @@ go build ./cmd/browser
 ./browser -output output.png -width 1024 -height 768 test/hackernews.html
 ```
 
-## Screenshots
+## 📸 Screenshots
 
-### Font Rendering
+### 🔤 Font Rendering
 
 The browser uses the [Go fonts](https://blog.golang.org/go-fonts) - high-quality, proportional, sans-serif fonts designed for the Go project. These fonts are embedded in the binary and provide excellent readability with support for bold, italic, and various sizes.
 
 ![Font Comparison](./font_comparison_screenshot.png)
 
-### Test Case Rendering
+### 🎨 Test Case Rendering
 
 Example of styled HTML with borders, colors, and text formatting:
 
 ![Test Case Rendering](./test_case_screenshot.png)
 
-### Hacker News
+### 📰 Hacker News
 
 Latest Hacker News render (1024x768):
 
 ![Hacker News Rendering](./hackernews_screenshot.png)
 
-### Testing
+### ✅ Testing
 
 ```bash
 go test ./...
 ```
 
-## WebAssembly
+## 🕸️ WebAssembly
 
 The browser can be compiled to WebAssembly and run entirely in a web browser. A live demo is available at **https://lukehoban.github.io/browser/** and is automatically deployed via GitHub Actions.
 
@@ -113,21 +113,21 @@ cd wasm && python3 -m http.server 8080
 
 See [wasm/README.md](wasm/README.md) for more details.
 
-## Documentation
+## 📚 Documentation
 
 - **[MILESTONES.md](MILESTONES.md)** - Implementation milestones and progress tracking
 - **[IMPLEMENTATION.md](IMPLEMENTATION.md)** - Detailed implementation summary and architecture
 - **[TESTING.md](TESTING.md)** - Testing strategy and public test suite integration
 
-## Current Status
+## 📊 Current Status
 
-✅ Milestones 1-7 Complete: Foundation, HTML Parsing, CSS Parsing, Style Computation, Layout Engine, Rendering, Image Rendering  
-✅ Milestone 9 Complete: Network Support (HTTP/HTTPS, external CSS, remote images)  
-✅ Milestone 9.5 Complete: Data URL Support (RFC 2397, base64 & URL-encoded inline resources)  
+✅ Milestones 1-7 Complete: Foundation, HTML Parsing, CSS Parsing, Style Computation, Layout Engine, Rendering, Image Rendering
+✅ Milestone 9 Complete: Network Support (HTTP/HTTPS, external CSS, remote images)
+✅ Milestone 9.5 Complete: Data URL Support (RFC 2397, base64 & URL-encoded inline resources)
 🔄 Milestone 8 In Progress: Testing & Validation (81.8% WPT pass rate)
 
 See [MILESTONES.md](MILESTONES.md) for detailed progress and known limitations.
 
-## License
+## 📄 License
 
 MIT


### PR DESCRIPTION
## Summary
This PR adds emoji icons throughout the README to make it more visually appealing and easier to scan. Emojis are added to:
- Section headers (✨, 📁, 📖, 🚀, 📸, 🕸️, 📚, 📊, 📄)
- Feature list items with relevant icons
- Subsection headers for Quick Start, Screenshots, and other sections

## Test plan
- [x] README renders correctly with emojis on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)