### PR TITLE
Improve mobile Wikipedia rendering

### DIFF
--- a/cmd/browser/main.go
+++ b/cmd/browser/main.go
@@ -380,7 +380,12 @@ func isURL(input string) bool {
 
 // fetchURL fetches content from a URL and returns it as a string
 func fetchURL(urlStr string) (string, error) {
-	resp, err := http.Get(urlStr)
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; GoBrowser/1.0; +https://github.com/lukehoban/browser)")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch URL: %w", err)
 	}

--- a/css/parser.go
+++ b/css/parser.go
@@ -73,9 +73,13 @@ func (p *Parser) Parse() *Stylesheet {
 			continue
 		}
 
+		savedPos := p.tokenizer.pos
 		rule := p.parseRule()
 		if rule != nil {
 			stylesheet.Rules = append(stylesheet.Rules, rule)
+		} else if p.tokenizer.pos == savedPos {
+			// Error recovery: if parsing didn't advance, skip to next rule
+			p.skipToNextRule()
 		}
 	}
 
@@ -109,6 +113,30 @@ func (p *Parser) skipAtRule() {
 			if braceDepth <= 0 {
 				break
 			}
+		}
+	}
+}
+
+// skipToNextRule skips tokens until the next rule boundary (after '}' or ';').
+// This is used for error recovery when parsing gets stuck.
+func (p *Parser) skipToNextRule() {
+	braceDepth := 0
+	for {
+		token := p.tokenizer.Next()
+		if token.Type == EOFToken {
+			break
+		}
+		if token.Type == LeftBraceToken {
+			braceDepth++
+		}
+		if token.Type == RightBraceToken {
+			braceDepth--
+			if braceDepth <= 0 {
+				break
+			}
+		}
+		if token.Type == SemicolonToken && braceDepth == 0 {
+			break
 		}
 	}
 }

--- a/css/parser.go
+++ b/css/parser.go
@@ -36,8 +36,9 @@ type SimpleSelector struct {
 // Declaration represents a CSS declaration.
 // CSS 2.1 §4.1.8 Declarations and properties
 type Declaration struct {
-	Property string
-	Value    string
+	Property  string
+	Value     string
+	Important bool // CSS 2.1 §6.4.2: !important flag
 }
 
 // Parser parses CSS stylesheets.
@@ -233,13 +234,14 @@ func (p *Parser) parseSelector() *Selector {
 		// CSS3 Selectors: General sibling combinator (~)
 		if next.Type == IdentToken {
 			if next.Value == ">" {
-				log.Warnf("CSS 2.1 §5.6: Child combinator (>) not yet implemented, skipping selector")
-				return nil
+				// Treat child combinator as descendant combinator (less strict but functional)
+				p.tokenizer.Next() // consume '>'
+				continue
 			} else if next.Value == "+" {
-				log.Warnf("CSS 2.1 §5.7: Adjacent sibling combinator (+) not yet implemented, skipping selector")
+				log.Debugf("CSS 2.1 §5.7: Adjacent sibling combinator (+) not yet implemented, skipping selector")
 				return nil
 			} else if next.Value == "~" {
-				log.Warnf("CSS3 Selectors: General sibling combinator (~) not yet implemented, skipping selector")
+				log.Debugf("CSS3 Selectors: General sibling combinator (~) not yet implemented, skipping selector")
 				return nil
 			}
 		}
@@ -428,17 +430,19 @@ func (p *Parser) parseDeclaration() *Declaration {
 			break
 		}
 		
-		// CSS 2.1 §6.4.2: Check for !important - not yet implemented
-		// Look ahead for '!' followed by 'important'
+		// CSS 2.1 §6.4.2: Check for !important
 		if token.Type == IdentToken && token.Value == "!" {
 			savedPos := p.tokenizer.pos
 			p.tokenizer.Next() // consume '!'
 			p.tokenizer.SkipWhitespace()
 			nextToken := p.tokenizer.Peek()
 			if nextToken.Type == IdentToken && nextToken.Value == "important" {
-				log.Warnf("CSS 2.1 §6.4.2: !important declarations not yet implemented (property: %s)", property)
 				p.tokenizer.Next() // consume "important"
-				break
+				return &Declaration{
+					Property:  property,
+					Value:     value,
+					Important: true,
+				}
 			}
 			// Not !important, restore and continue
 			p.tokenizer.pos = savedPos

--- a/css/tokenizer.go
+++ b/css/tokenizer.go
@@ -163,6 +163,10 @@ func (t *Tokenizer) Next() Token {
 		// Treat as an identifier for now to avoid breaking parsing
 		t.pos++
 		return Token{Type: IdentToken, Value: "~"}
+	case '*':
+		// CSS 2.1 §5.3: Universal selector
+		t.pos++
+		return Token{Type: IdentToken, Value: "*"}
 	case '{':
 		t.pos++
 		return Token{Type: LeftBraceToken, Value: "{"}

--- a/css/values.go
+++ b/css/values.go
@@ -275,8 +275,81 @@ func ParseColor(value string) color.RGBA {
 		return parseHexColor(value)
 	}
 
+	// CSS3: rgb() and rgba() functional notation
+	if strings.HasPrefix(value, "rgb(") || strings.HasPrefix(value, "rgba(") {
+		return parseRGBColor(value)
+	}
+
 	// Default to black
 	return color.RGBA{0, 0, 0, 255}
+}
+
+// parseRGBColor parses rgb() and rgba() color functions.
+// CSS3 Color Module: rgb(r, g, b) and rgba(r, g, b, a)
+func parseRGBColor(value string) color.RGBA {
+	// Strip function name and parentheses
+	inner := value
+	if strings.HasPrefix(inner, "rgba(") {
+		inner = strings.TrimPrefix(inner, "rgba(")
+	} else {
+		inner = strings.TrimPrefix(inner, "rgb(")
+	}
+	inner = strings.TrimSuffix(inner, ")")
+	inner = strings.TrimSpace(inner)
+
+	// Split by comma or space
+	var parts []string
+	if strings.Contains(inner, ",") {
+		parts = strings.Split(inner, ",")
+	} else {
+		parts = strings.Fields(inner)
+	}
+
+	if len(parts) < 3 {
+		return color.RGBA{0, 0, 0, 255}
+	}
+
+	r := parseColorComponent(strings.TrimSpace(parts[0]))
+	g := parseColorComponent(strings.TrimSpace(parts[1]))
+	b := parseColorComponent(strings.TrimSpace(parts[2]))
+	a := uint8(255)
+
+	if len(parts) >= 4 {
+		alphaStr := strings.TrimSpace(parts[3])
+		if strings.HasSuffix(alphaStr, "%") {
+			if pct, err := strconv.ParseFloat(strings.TrimSuffix(alphaStr, "%"), 64); err == nil {
+				a = uint8(pct * 255.0 / 100.0)
+			}
+		} else if alpha, err := strconv.ParseFloat(alphaStr, 64); err == nil {
+			if alpha <= 1.0 {
+				a = uint8(alpha * 255.0)
+			} else {
+				a = uint8(alpha)
+			}
+		}
+	}
+
+	return color.RGBA{r, g, b, a}
+}
+
+// parseColorComponent parses a single color component (0-255 or percentage).
+func parseColorComponent(s string) uint8 {
+	if strings.HasSuffix(s, "%") {
+		if pct, err := strconv.ParseFloat(strings.TrimSuffix(s, "%"), 64); err == nil {
+			return uint8(pct * 255.0 / 100.0)
+		}
+		return 0
+	}
+	if val, err := strconv.Atoi(s); err == nil {
+		if val < 0 {
+			return 0
+		}
+		if val > 255 {
+			return 255
+		}
+		return uint8(val)
+	}
+	return 0
 }
 
 // parseHexColor parses a hex color string (#RGB or #RRGGBB).

--- a/css/values.go
+++ b/css/values.go
@@ -52,6 +52,34 @@ func ParseFontSize(value string) float64 {
 		return 0
 	}
 
+	// CSS 2.1 §4.3.2: em units (relative to inherited font size)
+	// When used in font-size, em refers to the parent's font size
+	if strings.HasSuffix(value, "em") {
+		numStr := strings.TrimSuffix(value, "em")
+		if factor, err := strconv.ParseFloat(numStr, 64); err == nil && factor > 0 {
+			return factor * BaseFontHeight
+		}
+		return 0
+	}
+
+	// CSS 2.1 §4.3.2: rem units (relative to root font size)
+	if strings.HasSuffix(value, "rem") {
+		numStr := strings.TrimSuffix(value, "rem")
+		if factor, err := strconv.ParseFloat(numStr, 64); err == nil && factor > 0 {
+			return factor * BaseFontHeight
+		}
+		return 0
+	}
+
+	// Percentage (relative to inherited font size)
+	if strings.HasSuffix(value, "%") {
+		numStr := strings.TrimSuffix(value, "%")
+		if pct, err := strconv.ParseFloat(numStr, 64); err == nil && pct > 0 {
+			return BaseFontHeight * pct / 100.0
+		}
+		return 0
+	}
+
 	// Plain number (treat as pixels)
 	if size, err := strconv.ParseFloat(value, 64); err == nil && size > 0 {
 		return size

--- a/dom/loader.go
+++ b/dom/loader.go
@@ -65,7 +65,12 @@ func isDataURL(input string) bool {
 
 // loadFromURL fetches content from a URL.
 func loadFromURL(urlStr string) ([]byte, error) {
-	resp, err := http.Get(urlStr)
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; GoBrowser/1.0; +https://github.com/lukehoban/browser)")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch URL: %w", err)
 	}

--- a/dom/node.go
+++ b/dom/node.go
@@ -19,12 +19,13 @@ const (
 
 // Node represents a node in the DOM tree.
 type Node struct {
-	Type         NodeType
-	Data         string            // Tag name for elements, text content for text nodes
-	Attributes   map[string]string // Attributes for element nodes
-	Children     []*Node           // Child nodes
-	Parent       *Node             // Parent node (nil for root)
-	WrappedLines []string          // Pre-computed wrapped text lines (set during layout)
+	Type           NodeType
+	Data           string            // Tag name for elements, text content for text nodes
+	Attributes     map[string]string // Attributes for element nodes
+	Children       []*Node           // Child nodes
+	Parent         *Node             // Parent node (nil for root)
+	WrappedLines   []string          // Pre-computed wrapped text lines (set during layout)
+	ContainerWidth float64           // Width of containing block (for text-align)
 }
 
 // NewElement creates a new element node with the given tag name.

--- a/dom/node.go
+++ b/dom/node.go
@@ -19,11 +19,12 @@ const (
 
 // Node represents a node in the DOM tree.
 type Node struct {
-	Type       NodeType
-	Data       string            // Tag name for elements, text content for text nodes
-	Attributes map[string]string // Attributes for element nodes
-	Children   []*Node           // Child nodes
-	Parent     *Node             // Parent node (nil for root)
+	Type         NodeType
+	Data         string            // Tag name for elements, text content for text nodes
+	Attributes   map[string]string // Attributes for element nodes
+	Children     []*Node           // Child nodes
+	Parent       *Node             // Parent node (nil for root)
+	WrappedLines []string          // Pre-computed wrapped text lines (set during layout)
 }
 
 // NewElement creates a new element node with the given tag name.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lukehoban/browser
 
-go 1.24.11
+go 1.24.7
 
 require golang.org/x/image v0.34.0
 

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -816,7 +816,7 @@ func (box *LayoutBox) layoutText(containingBlock Dimensions) {
 
 	// Calculate dimensions based on wrapped lines
 	maxLineWidth := 0.0
-	lineHeight := fontSize * 1.2 // CSS default line-height is ~1.2
+	lineHeight := resolveLineHeight(box.StyledNode.Styles, fontSize)
 	totalHeight := lineHeight * float64(len(lines))
 
 	for _, line := range lines {
@@ -832,9 +832,10 @@ func (box *LayoutBox) layoutText(containingBlock Dimensions) {
 	box.Dimensions.Content.Width = maxLineWidth
 	box.Dimensions.Content.Height = totalHeight
 
-	// Store wrapped lines for rendering
+	// Store wrapped lines and container width for rendering (text-align)
 	if box.StyledNode != nil {
 		box.StyledNode.Node.WrappedLines = lines
+		box.StyledNode.Node.ContainerWidth = containingBlock.Content.Width
 	}
 }
 
@@ -866,6 +867,43 @@ func wrapText(text string, fontStyle font.Style, maxWidth float64) []string {
 	lines = append(lines, currentLine)
 
 	return lines
+}
+
+// resolveLineHeight resolves the CSS line-height property to a pixel value.
+// CSS 2.1 §10.8.1: Line height calculations
+func resolveLineHeight(styles map[string]string, fontSize float64) float64 {
+	lh := styles["line-height"]
+	if lh == "" || lh == "normal" {
+		return fontSize * 1.2 // CSS 2.1 default
+	}
+
+	// Unitless number - multiply by font size
+	if num, err := strconv.ParseFloat(lh, 64); err == nil {
+		return num * fontSize
+	}
+
+	// em units
+	if strings.HasSuffix(lh, "em") {
+		if em, err := strconv.ParseFloat(lh[:len(lh)-2], 64); err == nil {
+			return em * fontSize
+		}
+	}
+
+	// px units
+	if strings.HasSuffix(lh, "px") {
+		if px, err := strconv.ParseFloat(lh[:len(lh)-2], 64); err == nil {
+			return px
+		}
+	}
+
+	// Percentage
+	if strings.HasSuffix(lh, "%") {
+		if pct, err := strconv.ParseFloat(lh[:len(lh)-1], 64); err == nil {
+			return fontSize * pct / 100.0
+		}
+	}
+
+	return fontSize * 1.2
 }
 
 // extractFontSize extracts the font-size from CSS styles and returns it in pixels.

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -409,7 +409,10 @@ func (box *LayoutBox) calculateBlockPosition(containingBlock Dimensions) {
 }
 
 // layoutBlockChildren lays out the children of a block box.
+// CSS 2.1 §8.3.1: Implements vertical margin collapsing between adjacent block boxes.
 func (box *LayoutBox) layoutBlockChildren() {
+	prevMarginBottom := 0.0
+
 	for i := 0; i < len(box.Children); {
 		child := box.Children[i]
 
@@ -421,12 +424,24 @@ func (box *LayoutBox) layoutBlockChildren() {
 				i++
 			}
 			box.layoutInlineChildren(inlineRun)
+			prevMarginBottom = 0
 			continue
 		}
 
-		// Block-level layout (existing behavior)
+		// Block-level layout
 		child.Layout(box.Dimensions)
+
+		// CSS 2.1 §8.3.1: Vertical margin collapsing
+		// Adjacent block-level boxes collapse their vertical margins
+		if prevMarginBottom > 0 && child.Dimensions.Margin.Top > 0 {
+			// Collapse: use the larger margin, subtract the smaller one
+			collapsed := math.Min(prevMarginBottom, child.Dimensions.Margin.Top)
+			child.shiftY(-collapsed)
+			box.Dimensions.Content.Height -= collapsed
+		}
+
 		box.Dimensions.Content.Height += child.marginBox().Height
+		prevMarginBottom = child.Dimensions.Margin.Bottom
 		i++
 	}
 }
@@ -964,20 +979,16 @@ func collapseWhitespace(text string) string {
 // CSS 2.1 §17.5 Visual layout of table contents
 // CSS 2.1 §17.6.1: Border-spacing property adds space between cells
 func (box *LayoutBox) layoutTable(containingBlock Dimensions) {
-	// CSS 2.1 §17.6.2: Border-collapse model - not yet implemented
-	if borderCollapse := box.StyledNode.Styles["border-collapse"]; borderCollapse == "collapse" {
-		log.Warnf("CSS 2.1 §17.6.2: border-collapse:collapse not yet implemented, using separate borders")
-	}
-	
 	// Calculate table width (similar to block)
 	box.calculateBlockWidth(containingBlock)
 	box.calculateBlockPosition(containingBlock)
 
 	// Get border-spacing value (CSS 2.1 §17.6.1)
-	// For simplicity, we use the same spacing for horizontal and vertical
-	// (full spec supports "horizontal vertical" syntax)
 	borderSpacing := 2.0 // Default from user-agent stylesheet
-	if spacing := box.StyledNode.Styles["border-spacing"]; spacing != "" {
+	if borderCollapse := box.StyledNode.Styles["border-collapse"]; borderCollapse == "collapse" {
+		// CSS 2.1 §17.6.2: In the collapsing border model, border-spacing is 0
+		borderSpacing = 0
+	} else if spacing := box.StyledNode.Styles["border-spacing"]; spacing != "" {
 		if parsed := parseLength(spacing, 0); parsed >= 0 {
 			borderSpacing = parsed
 		}

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -319,9 +319,9 @@ func (box *LayoutBox) calculateBlockWidth(containingBlock Dimensions) {
 	// Default to auto
 	width := parseLength(styles["width"], containingBlock.Content.Width)
 
-	// Margins (default to 0 if not specified)
-	marginLeft := parseLengthOr0(styles["margin-left"], containingBlock.Content.Width)
-	marginRight := parseLengthOr0(styles["margin-right"], containingBlock.Content.Width)
+	// Margins (default to 0 if not specified; can be negative per CSS 2.1 §8.3)
+	marginLeft := parseMargin(styles["margin-left"], containingBlock.Content.Width)
+	marginRight := parseMargin(styles["margin-right"], containingBlock.Content.Width)
 
 	// Padding (default to 0)
 	paddingLeft := parseLengthOr0(styles["padding-left"], containingBlock.Content.Width)
@@ -383,9 +383,9 @@ func (box *LayoutBox) calculateBlockWidth(containingBlock Dimensions) {
 func (box *LayoutBox) calculateBlockPosition(containingBlock Dimensions) {
 	styles := box.StyledNode.Styles
 
-	// Margin (default to 0)
-	box.Dimensions.Margin.Top = parseLengthOr0(styles["margin-top"], containingBlock.Content.Width)
-	box.Dimensions.Margin.Bottom = parseLengthOr0(styles["margin-bottom"], containingBlock.Content.Width)
+	// Margin (can be negative per CSS 2.1 §8.3)
+	box.Dimensions.Margin.Top = parseMargin(styles["margin-top"], containingBlock.Content.Width)
+	box.Dimensions.Margin.Bottom = parseMargin(styles["margin-bottom"], containingBlock.Content.Width)
 
 	// Padding (default to 0)
 	box.Dimensions.Padding.Top = parseLengthOr0(styles["padding-top"], containingBlock.Content.Width)
@@ -751,6 +751,20 @@ func parseLengthOr0(value string, referenceLength float64) float64 {
 	return result
 }
 
+// parseMargin parses a CSS margin value, allowing negative values.
+// CSS 2.1 §8.3: Margins can be negative.
+func parseMargin(value string, referenceLength float64) float64 {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "auto" {
+		return 0
+	}
+	result := parseLengthWithFont(value, referenceLength, css.BaseFontHeight)
+	if result == -1 {
+		return 0 // "auto" or invalid
+	}
+	return result
+}
+
 // marginBox returns the box including margin.
 func (box *LayoutBox) marginBox() Rect {
 	return expandRect(box.borderBox(), box.Dimensions.Margin)
@@ -856,6 +870,8 @@ func (box *LayoutBox) layoutText(containingBlock Dimensions) {
 
 // wrapText breaks text into lines that fit within the given width.
 // CSS 2.1 §16.6: Line breaking occurs at word boundaries.
+// CSS3 overflow-wrap: If a single word exceeds the line width, it overflows
+// (we don't break mid-word to keep rendering simple).
 func wrapText(text string, fontStyle font.Style, maxWidth float64) []string {
 	if maxWidth <= 0 {
 		return []string{text}
@@ -867,9 +883,13 @@ func wrapText(text string, fontStyle font.Style, maxWidth float64) []string {
 	}
 
 	var lines []string
-	currentLine := words[0]
+	currentLine := ""
 
-	for _, word := range words[1:] {
+	for _, word := range words {
+		if currentLine == "" {
+			currentLine = word
+			continue
+		}
 		testLine := currentLine + " " + word
 		w, _ := font.MeasureText(testLine, fontStyle)
 		if w <= maxWidth {
@@ -879,7 +899,9 @@ func wrapText(text string, fontStyle font.Style, maxWidth float64) []string {
 			currentLine = word
 		}
 	}
-	lines = append(lines, currentLine)
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
 
 	return lines
 }

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -184,6 +184,11 @@ func buildLayoutTree(styledNode *style.StyledNode) *LayoutBox {
 		display = "block"
 	}
 
+	// CSS 2.1 §9.2.4: Inline-block - treat as block for layout purposes
+	if display == "inline-block" {
+		display = "block"
+	}
+
 	// If no explicit display property, infer from HTML element
 	if display == "" && styledNode.Node != nil && styledNode.Node.Type == dom.ElementNode {
 		switch styledNode.Node.Data {
@@ -211,7 +216,15 @@ func buildLayoutTree(styledNode *style.StyledNode) *LayoutBox {
 			display = "inline"
 		// HTML5 §10.3.1: Elements that should not be rendered
 		// These elements have display:none in the default UA stylesheet
-		case "head", "title", "meta", "link", "style", "script", "noscript", "base":
+		case "head", "title", "meta", "link", "style", "script", "noscript", "base",
+			"template":
+			display = "none"
+		}
+	}
+
+	// HTML5 §4.9.1: The hidden attribute hides elements
+	if styledNode.Node != nil && styledNode.Node.Type == dom.ElementNode {
+		if styledNode.Node.GetAttribute("hidden") != "" {
 			display = "none"
 		}
 	}
@@ -421,66 +434,99 @@ func (box *LayoutBox) layoutBlockChildren() {
 // layoutInlineChildren lays out a run of inline-level children within this block box.
 // CSS 2.1 §9.4.2 Inline formatting contexts: inline-level boxes are laid out in horizontal line boxes.
 // CSS 2.1 §10.8: Line height and baseline alignment
+// Supports line wrapping when inline content exceeds the containing block width.
 func (box *LayoutBox) layoutInlineChildren(children []*LayoutBox) {
 	if len(children) == 0 {
 		return
 	}
 
-	currentX := box.Dimensions.Content.X
+	containerWidth := box.Dimensions.Content.Width
+	startX := box.Dimensions.Content.X
+	currentX := startX
 	currentY := box.Dimensions.Content.Y + box.Dimensions.Content.Height
 
-	// First pass: layout all children to calculate their dimensions
-	// and find the maximum baseline (for baseline alignment)
-	maxBaseline := 0.0
-	maxHeight := 0.0
+	// Track current line for baseline alignment
+	type lineInfo struct {
+		children  []*LayoutBox
+		maxHeight float64
+	}
+	var lines []lineInfo
+	currentLine := lineInfo{}
 
-	for i, child := range children {
+	for _, child := range children {
 		inlineCB := Dimensions{
 			Content: Rect{
 				X:      currentX,
 				Y:      currentY,
-				Width:  math.Max(0, box.Dimensions.Content.Width-(currentX-box.Dimensions.Content.X)),
+				Width:  math.Max(0, containerWidth-(currentX-startX)),
 				Height: 0,
 			},
 		}
 
 		child.Layout(inlineCB)
 
-		// Position child horizontally
+		childWidth := child.marginBox().Width
+
+		// Check if we need to wrap to next line
+		// Only wrap if we're not at the start of a line and the child doesn't fit
+		if currentX > startX && (currentX-startX)+childWidth > containerWidth && containerWidth > 0 {
+			// Finish current line
+			lines = append(lines, currentLine)
+			currentY += currentLine.maxHeight
+			currentX = startX
+			currentLine = lineInfo{}
+
+			// Re-layout child with full line width
+			inlineCB.Content.X = currentX
+			inlineCB.Content.Y = currentY
+			inlineCB.Content.Width = containerWidth
+			child.Layout(inlineCB)
+			childWidth = child.marginBox().Width
+		}
+
+		// Position child
 		child.Dimensions.Content.X = currentX + child.Dimensions.Margin.Left + child.Dimensions.Border.Left + child.Dimensions.Padding.Left
 		child.Dimensions.Content.Y = currentY + child.Dimensions.Margin.Top + child.Dimensions.Border.Top + child.Dimensions.Padding.Top
 
-		currentX += child.marginBox().Width
+		currentX += childWidth + calculateWordSpacing(child)
 
-		// CSS 2.1 §16.4: Add word-spacing between adjacent inline elements
-		if i < len(children)-1 {
-			currentX += calculateWordSpacing(child)
+		// Track line height
+		h := child.marginBox().Height
+		if h > currentLine.maxHeight {
+			currentLine.maxHeight = h
 		}
+		currentLine.children = append(currentLine.children, child)
+	}
 
-		// Track maximum baseline offset (font size approximates baseline position)
-		baseline := getBaseline(child)
-		if baseline > maxBaseline {
-			maxBaseline = baseline
+	// Add final line
+	if len(currentLine.children) > 0 {
+		lines = append(lines, currentLine)
+	}
+
+	// Apply baseline alignment within each line
+	for _, line := range lines {
+		maxBaseline := 0.0
+		for _, child := range line.children {
+			baseline := getBaseline(child)
+			if baseline > maxBaseline {
+				maxBaseline = baseline
+			}
 		}
-
-		if child.marginBox().Height > maxHeight {
-			maxHeight = child.marginBox().Height
+		for _, child := range line.children {
+			baseline := getBaseline(child)
+			baselineOffset := maxBaseline - baseline
+			if baselineOffset > 0 {
+				child.shiftY(baselineOffset)
+			}
 		}
 	}
 
-	// Second pass: align all children to the common baseline
-	// CSS 2.1 §10.8.1: Inline elements are aligned by their baselines
-	for _, child := range children {
-		baseline := getBaseline(child)
-		// Shift elements with smaller baselines down to align with the maximum baseline
-		baselineOffset := maxBaseline - baseline
-		if baselineOffset > 0 {
-			child.shiftY(baselineOffset)
-		}
+	// Increase parent height by total line heights
+	totalHeight := 0.0
+	for _, line := range lines {
+		totalHeight += line.maxHeight
 	}
-
-	// Increase parent height by the tallest inline box on this line
-	box.Dimensions.Content.Height += maxHeight
+	box.Dimensions.Content.Height += totalHeight
 }
 
 // getBaseline returns the baseline offset for an inline element.
@@ -533,11 +579,12 @@ func (box *LayoutBox) layoutInlineBox(containingBlock Dimensions) {
 
 	currentX := box.Dimensions.Content.X
 	currentY := box.Dimensions.Content.Y
-	maxBaseline := 0.0
-	maxHeight := 0.0
+	maxWidth := 0.0
+	totalHeight := 0.0
+	lineHeight := 0.0
 
-	// First pass: layout all children to calculate their dimensions
-	for i, child := range box.Children {
+	// Layout children with wrapping support
+	for _, child := range box.Children {
 		inlineCB := Dimensions{
 			Content: Rect{
 				X:      currentX,
@@ -553,36 +600,23 @@ func (box *LayoutBox) layoutInlineBox(containingBlock Dimensions) {
 		child.Dimensions.Content.X = currentX + child.Dimensions.Margin.Left + child.Dimensions.Border.Left + child.Dimensions.Padding.Left
 		child.Dimensions.Content.Y = currentY + child.Dimensions.Margin.Top + child.Dimensions.Border.Top + child.Dimensions.Padding.Top
 
-		currentX += child.marginBox().Width
+		currentX += child.marginBox().Width + calculateWordSpacing(child)
 
-		// CSS 2.1 §16.4: Add word-spacing between adjacent inline elements
-		if i < len(box.Children)-1 {
-			currentX += calculateWordSpacing(child)
+		h := child.marginBox().Height
+		if h > lineHeight {
+			lineHeight = h
 		}
 
-		// Track maximum baseline offset
-		baseline := getBaseline(child)
-		if baseline > maxBaseline {
-			maxBaseline = baseline
-		}
-
-		if child.marginBox().Height > maxHeight {
-			maxHeight = child.marginBox().Height
+		w := currentX - box.Dimensions.Content.X
+		if w > maxWidth {
+			maxWidth = w
 		}
 	}
 
-	// Second pass: align all children to the common baseline
-	// CSS 2.1 §10.8.1: Inline elements are aligned by their baselines
-	for _, child := range box.Children {
-		baseline := getBaseline(child)
-		baselineOffset := maxBaseline - baseline
-		if baselineOffset > 0 {
-			child.shiftY(baselineOffset)
-		}
-	}
+	totalHeight = lineHeight
 
-	box.Dimensions.Content.Width = currentX - box.Dimensions.Content.X
-	box.Dimensions.Content.Height = maxHeight
+	box.Dimensions.Content.Width = maxWidth
+	box.Dimensions.Content.Height = totalHeight
 }
 
 // calculateWordSpacing calculates the word spacing to add between inline elements.
@@ -1029,8 +1063,11 @@ func (box *LayoutBox) calculateColumnWidths(numColumns int, tableWidth float64) 
 				columnWidths[i] = w * scale
 			}
 		} else {
-			// Content exceeds table width - use minimum widths
-			copy(columnWidths, columnMinWidths)
+			// Content exceeds table width - scale down proportionally to fit
+			scale := tableWidth / totalMinWidth
+			for i, w := range columnMinWidths {
+				columnWidths[i] = w * scale
+			}
 		}
 	} else {
 		// Equal distribution if no content found
@@ -1063,8 +1100,12 @@ func (box *LayoutBox) estimateCellMinWidth(cell *LayoutBox) float64 {
 	}
 
 	// Cap at reasonable maximum to prevent extremely wide content from creating unusable layouts
-	if minWidth > maxColumnWidth {
-		minWidth = maxColumnWidth
+	maxWidth := maxColumnWidth
+	if maxWidth > box.Dimensions.Content.Width && box.Dimensions.Content.Width > 0 {
+		maxWidth = box.Dimensions.Content.Width
+	}
+	if minWidth > maxWidth {
+		minWidth = maxWidth
 	}
 
 	return minWidth

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -125,8 +125,11 @@ type EdgeSizes struct {
 // LayoutTree builds a layout tree from a styled tree.
 // CSS 2.1 §9.2 Controlling box generation
 func LayoutTree(styledNode *style.StyledNode, containingBlock Dimensions) *LayoutBox {
-	// Set initial containing block dimensions
-	containingBlock.Content.Width = 800.0 // Default viewport width
+	// Use the viewport width from the containing block (set by the caller)
+	// Fall back to 800px if not specified
+	if containingBlock.Content.Width <= 0 {
+		containingBlock.Content.Width = 800.0
+	}
 
 	root := buildLayoutTree(styledNode)
 	root.Layout(containingBlock)
@@ -193,7 +196,18 @@ func buildLayoutTree(styledNode *style.StyledNode) *LayoutBox {
 		// CSS 2.1 §9.2.2: Inline-level elements and inline boxes
 		// These elements generate inline boxes by default
 		case "a", "span", "b", "strong", "i", "em", "font", "code", "small", "big",
-			"abbr", "cite", "kbd", "samp", "var", "sub", "sup", "mark", "u", "s", "del", "ins":
+			"abbr", "cite", "kbd", "samp", "var", "sub", "sup", "mark", "u", "s", "del", "ins",
+			"time", "label", "q":
+			display = "inline"
+		// HTML5 §4.3-4.4: Semantic sectioning and grouping elements are block-level
+		case "section", "article", "nav", "aside", "header", "footer", "main",
+			"figure", "figcaption", "details", "summary", "dialog":
+			display = "block"
+		// HTML5 §12.1.2: Void elements that create line breaks
+		case "br":
+			display = "block"
+		// HTML5 §4.8.2: Images are replaced inline elements
+		case "img":
 			display = "inline"
 		// HTML5 §10.3.1: Elements that should not be rendered
 		// These elements have display:none in the default UA stylesheet
@@ -321,6 +335,24 @@ func (box *LayoutBox) calculateBlockWidth(containingBlock Dimensions) {
 			borderLeft - borderRight - paddingLeft - paddingRight
 		if width < 0 {
 			width = 0
+		}
+	}
+
+	// CSS 2.1 §10.4: Apply max-width constraint
+	if maxWidthStr := styles["max-width"]; maxWidthStr != "" {
+		if maxWidth := parseLength(maxWidthStr, containingBlock.Content.Width); maxWidth >= 0 {
+			if width > maxWidth {
+				width = maxWidth
+			}
+		}
+	}
+
+	// CSS 2.1 §10.4: Apply min-width constraint
+	if minWidthStr := styles["min-width"]; minWidthStr != "" {
+		if minWidth := parseLength(minWidthStr, containingBlock.Content.Width); minWidth >= 0 {
+			if width < minWidth {
+				width = minWidth
+			}
 		}
 	}
 
@@ -592,9 +624,16 @@ func (box *LayoutBox) calculateBlockHeight() {
 // Returns -1 if the value is "auto" or invalid.
 // CSS 2.1 §4.3.2 Lengths
 func parseLength(value string, referenceLength float64) float64 {
+	return parseLengthWithFont(value, referenceLength, css.BaseFontHeight)
+}
+
+// parseLengthWithFont parses a CSS length value with a specific font size for em units.
+// Returns -1 if the value is "auto" or invalid.
+// CSS 2.1 §4.3.2 Lengths
+func parseLengthWithFont(value string, referenceLength float64, fontSize float64) float64 {
 	value = strings.TrimSpace(value)
 
-	if value == "" || value == "auto" {
+	if value == "" || value == "auto" || value == "none" {
 		return -1
 	}
 
@@ -610,6 +649,38 @@ func parseLength(value string, referenceLength float64) float64 {
 	if strings.HasSuffix(value, "px") {
 		if px, err := strconv.ParseFloat(value[:len(value)-2], 64); err == nil {
 			return px
+		}
+		return -1
+	}
+
+	// Parse em units - CSS 2.1 §4.3.2: relative to font-size of the element
+	if strings.HasSuffix(value, "em") {
+		if em, err := strconv.ParseFloat(value[:len(value)-2], 64); err == nil {
+			return em * fontSize
+		}
+		return -1
+	}
+
+	// Parse rem units - CSS3: relative to root font-size
+	if strings.HasSuffix(value, "rem") {
+		if rem, err := strconv.ParseFloat(value[:len(value)-3], 64); err == nil {
+			return rem * css.BaseFontHeight
+		}
+		return -1
+	}
+
+	// Parse pt units - CSS 2.1 §4.3.2: 1pt = 1/72 inch, at 96dpi: 1pt ≈ 1.333px
+	if strings.HasSuffix(value, "pt") {
+		if pt, err := strconv.ParseFloat(value[:len(value)-2], 64); err == nil {
+			return pt * 96.0 / 72.0
+		}
+		return -1
+	}
+
+	// Parse vw units - CSS3: 1vw = 1% of viewport width
+	if strings.HasSuffix(value, "vw") {
+		if vw, err := strconv.ParseFloat(value[:len(value)-2], 64); err == nil {
+			return referenceLength * vw / 100.0
 		}
 		return -1
 	}
@@ -668,8 +739,9 @@ func applyExplicitRowHeight(box *LayoutBox, styles map[string]string) bool {
 	return true
 }
 
-// layoutText lays out a text node.
+// layoutText lays out a text node with word wrapping.
 // CSS 2.1 §16 Text
+// CSS 2.1 §9.4.2: Text is wrapped at the edge of the containing block
 func (box *LayoutBox) layoutText(containingBlock Dimensions) {
 	// Get the text content
 	text := box.StyledNode.Node.Data
@@ -680,7 +752,6 @@ func (box *LayoutBox) layoutText(containingBlock Dimensions) {
 	}
 
 	// CSS 2.1 §16.6.1: Collapse whitespace for layout calculations
-	// This ensures dimensions match what will actually be rendered
 	text = collapseWhitespace(text)
 
 	if text == "" {
@@ -693,21 +764,74 @@ func (box *LayoutBox) layoutText(containingBlock Dimensions) {
 	fontSize := extractFontSize(box.StyledNode.Styles)
 	fontWeight := extractFontWeight(box.StyledNode.Styles)
 	fontStyleStr := extractFontStyle(box.StyledNode.Styles)
-	
-	// Measure text using shared font.MeasureText
-	// This ensures layout and rendering use the same measurements
+
 	fontStyle := font.Style{
 		Size:   fontSize,
 		Weight: fontWeight,
 		Style:  fontStyleStr,
 	}
-	width, height := font.MeasureText(text, fontStyle)
+
+	// Available width for text wrapping
+	availableWidth := containingBlock.Content.Width
+	if availableWidth <= 0 {
+		availableWidth = 800
+	}
+
+	// Wrap text into lines that fit the available width
+	lines := wrapText(text, fontStyle, availableWidth)
+
+	// Calculate dimensions based on wrapped lines
+	maxLineWidth := 0.0
+	lineHeight := fontSize * 1.2 // CSS default line-height is ~1.2
+	totalHeight := lineHeight * float64(len(lines))
+
+	for _, line := range lines {
+		w, _ := font.MeasureText(line, fontStyle)
+		if w > maxLineWidth {
+			maxLineWidth = w
+		}
+	}
 
 	// Position the text node
 	box.Dimensions.Content.X = containingBlock.Content.X
 	box.Dimensions.Content.Y = containingBlock.Content.Y + containingBlock.Content.Height
-	box.Dimensions.Content.Width = width
-	box.Dimensions.Content.Height = height
+	box.Dimensions.Content.Width = maxLineWidth
+	box.Dimensions.Content.Height = totalHeight
+
+	// Store wrapped lines for rendering
+	if box.StyledNode != nil {
+		box.StyledNode.Node.WrappedLines = lines
+	}
+}
+
+// wrapText breaks text into lines that fit within the given width.
+// CSS 2.1 §16.6: Line breaking occurs at word boundaries.
+func wrapText(text string, fontStyle font.Style, maxWidth float64) []string {
+	if maxWidth <= 0 {
+		return []string{text}
+	}
+
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{}
+	}
+
+	var lines []string
+	currentLine := words[0]
+
+	for _, word := range words[1:] {
+		testLine := currentLine + " " + word
+		w, _ := font.MeasureText(testLine, fontStyle)
+		if w <= maxWidth {
+			currentLine = testLine
+		} else {
+			lines = append(lines, currentLine)
+			currentLine = word
+		}
+	}
+	lines = append(lines, currentLine)
+
+	return lines
 }
 
 // extractFontSize extracts the font-size from CSS styles and returns it in pixels.

--- a/render/render.go
+++ b/render/render.go
@@ -746,21 +746,6 @@ func renderText(canvas *Canvas, box *layout.LayoutBox) {
 		return
 	}
 
-	// Get the text content
-	text := box.StyledNode.Node.Data
-	if text == "" {
-		return
-	}
-
-	// CSS 2.1 §16.6.1: Whitespace processing
-	// Collapse sequences of whitespace (spaces, tabs, newlines) into a single space
-	// This is the default behavior for normal text (not pre-formatted)
-	text = collapseWhitespace(text)
-	
-	if text == "" {
-		return
-	}
-
 	// Get text color from styles (default to black)
 	textColor := css.ParseColor(box.StyledNode.Styles["color"])
 	if textColor == (color.RGBA{0, 0, 0, 0}) {
@@ -769,9 +754,29 @@ func renderText(canvas *Canvas, box *layout.LayoutBox) {
 
 	// Extract font properties from styles
 	fontStyle := extractFontStyle(box.StyledNode.Styles)
-	
-	// Render the text at the box's position
-	// Add a vertical offset to position text at baseline
+
+	// Check if we have pre-wrapped lines from layout
+	if lines := box.StyledNode.Node.WrappedLines; len(lines) > 0 {
+		x := int(box.Dimensions.Content.X)
+		lineHeight := fontStyle.Size * 1.2
+		for i, line := range lines {
+			y := int(box.Dimensions.Content.Y) + int(fontStyle.Size) + int(float64(i)*lineHeight)
+			canvas.DrawStyledText(line, x, y, textColor, fontStyle)
+		}
+		return
+	}
+
+	// Fallback: render single line (for inline text without wrapping)
+	text := box.StyledNode.Node.Data
+	if text == "" {
+		return
+	}
+
+	text = collapseWhitespace(text)
+	if text == "" {
+		return
+	}
+
 	x := int(box.Dimensions.Content.X)
 	y := int(box.Dimensions.Content.Y) + int(fontStyle.Size)
 

--- a/render/render.go
+++ b/render/render.go
@@ -802,10 +802,27 @@ func renderText(canvas *Canvas, box *layout.LayoutBox) {
 	// Check if we have pre-wrapped lines from layout
 	if lines := box.StyledNode.Node.WrappedLines; len(lines) > 0 {
 		x := int(box.Dimensions.Content.X)
+		// Use the container width (from parent block) for text-align, not the text's own width
+		containerWidth := box.StyledNode.Node.ContainerWidth
+		if containerWidth <= 0 {
+			containerWidth = box.Dimensions.Content.Width
+		}
 		lineHeight := fontStyle.Size * 1.2
+		textAlign := box.StyledNode.Styles["text-align"]
+
 		for i, line := range lines {
+			lineX := x
+			// CSS 2.1 §16.2: Apply text-align
+			if textAlign == "center" || textAlign == "right" {
+				lineWidth, _ := browserfont.MeasureText(line, browserfont.Style(fontStyle))
+				if textAlign == "center" {
+					lineX = x + int((containerWidth-lineWidth)/2)
+				} else {
+					lineX = x + int(containerWidth-lineWidth)
+				}
+			}
 			y := int(box.Dimensions.Content.Y) + int(fontStyle.Size) + int(float64(i)*lineHeight)
-			canvas.DrawStyledText(line, x, y, textColor, fontStyle)
+			canvas.DrawStyledText(line, lineX, y, textColor, fontStyle)
 		}
 		return
 	}

--- a/render/render.go
+++ b/render/render.go
@@ -551,9 +551,53 @@ func renderLayoutBox(canvas *Canvas, box *layout.LayoutBox) {
 	renderBorders(canvas, box)
 	renderText(canvas, box)
 	renderImage(canvas, box)
+	renderListMarker(canvas, box)
 
 	for _, child := range box.Children {
 		renderLayoutBox(canvas, child)
+	}
+}
+
+// renderListMarker renders a bullet marker for list items.
+// CSS 2.1 §12.5: Lists
+func renderListMarker(canvas *Canvas, box *layout.LayoutBox) {
+	if box.StyledNode == nil || box.StyledNode.Node == nil {
+		return
+	}
+
+	// Only render markers for <li> elements
+	if box.StyledNode.Node.Type != dom.ElementNode || box.StyledNode.Node.Data != "li" {
+		return
+	}
+
+	// Get text color (default to black)
+	textColor := css.ParseColor(box.StyledNode.Styles["color"])
+	if textColor == (color.RGBA{0, 0, 0, 0}) {
+		textColor = color.RGBA{0, 0, 0, 255}
+	}
+
+	// Draw a bullet disc to the left of the content
+	fontSize := 13.0
+	if fs := box.StyledNode.Styles["font-size"]; fs != "" {
+		if size := css.ParseFontSize(fs); size > 0 {
+			fontSize = size
+		}
+	}
+
+	bulletSize := int(fontSize * 0.3)
+	if bulletSize < 2 {
+		bulletSize = 2
+	}
+
+	// Position bullet to the left of content, vertically centered on first line
+	bulletX := int(box.Dimensions.Content.X) - bulletSize*3
+	bulletY := int(box.Dimensions.Content.Y) + int(fontSize*0.4)
+
+	// Draw filled circle (approximated as a small square for simplicity)
+	for dy := 0; dy < bulletSize; dy++ {
+		for dx := 0; dx < bulletSize; dx++ {
+			canvas.SetPixel(bulletX+dx, bulletY+dy, textColor)
+		}
 	}
 }
 

--- a/style/style.go
+++ b/style/style.go
@@ -140,11 +140,21 @@ func styleNode(node *dom.Node, stylesheet *css.Stylesheet, parentStyles map[stri
 		// Find all matching rules
 		matchedRules := matchRules(node, stylesheet)
 
-		// Apply rules in order of specificity
+		// CSS 2.1 §6.4.2: Apply rules in order of specificity,
+		// then apply !important declarations (which override everything)
+		importantDecls := make([]*css.Declaration, 0)
 		for _, matched := range matchedRules {
 			for _, decl := range matched.Rule.Declarations {
-				applyDeclaration(decl, styled.Styles)
+				if decl.Important {
+					importantDecls = append(importantDecls, decl)
+				} else {
+					applyDeclaration(decl, styled.Styles)
+				}
 			}
+		}
+		// Apply !important declarations last so they override everything
+		for _, decl := range importantDecls {
+			applyDeclaration(decl, styled.Styles)
 		}
 		
 		// cellpadding and cellspacing attribute handling

--- a/style/style.go
+++ b/style/style.go
@@ -280,8 +280,8 @@ func matchesDescendant(node *dom.Node, selectors []*css.SimpleSelector) bool {
 // matchesSimpleSelector checks if a node matches a simple selector.
 // CSS 2.1 §5.2 Selector syntax
 func matchesSimpleSelector(node *dom.Node, selector *css.SimpleSelector) bool {
-	// Check element type
-	if selector.TagName != "" && selector.TagName != node.Data {
+	// Check element type ("*" is universal selector - matches any element)
+	if selector.TagName != "" && selector.TagName != "*" && selector.TagName != node.Data {
 		return false
 	}
 

--- a/style/style.go
+++ b/style/style.go
@@ -197,6 +197,15 @@ func styleNode(node *dom.Node, stylesheet *css.Stylesheet, parentStyles map[stri
 				applyDeclaration(decl, styled.Styles)
 			}
 		}
+
+		// Resolve relative font-size values (em, %, rem) against parent
+		// Done after all style application so inline styles are included
+		if fs := styled.Styles["font-size"]; fs != "" {
+			resolvedSize := resolveRelativeFontSize(fs, parentStyles)
+			if resolvedSize > 0 {
+				styled.Styles["font-size"] = strconv.FormatFloat(resolvedSize, 'f', 1, 64) + "px"
+			}
+		}
 	}
 
 	// Recursively style children
@@ -368,12 +377,67 @@ func calculateSpecificity(selector *css.Selector) Specificity {
 	return spec
 }
 
+// resolveRelativeFontSize resolves relative font-size values (em, %, rem) against parent.
+// CSS 2.1 §15.7: When font-size uses relative units, it's relative to the parent's font-size.
+func resolveRelativeFontSize(value string, parentStyles map[string]string) float64 {
+	value = strings.TrimSpace(strings.ToLower(value))
+
+	// Get parent's computed font size
+	parentSize := css.BaseFontHeight
+	if parentFS := parentStyles["font-size"]; parentFS != "" {
+		if ps := css.ParseFontSize(parentFS); ps > 0 {
+			parentSize = ps
+		}
+	}
+
+	// em units - relative to parent font size
+	if strings.HasSuffix(value, "em") && !strings.HasSuffix(value, "rem") {
+		numStr := strings.TrimSuffix(value, "em")
+		if factor, err := strconv.ParseFloat(numStr, 64); err == nil && factor > 0 {
+			return factor * parentSize
+		}
+	}
+
+	// Percentage - relative to parent font size
+	if strings.HasSuffix(value, "%") {
+		numStr := strings.TrimSuffix(value, "%")
+		if pct, err := strconv.ParseFloat(numStr, 64); err == nil && pct > 0 {
+			return parentSize * pct / 100.0
+		}
+	}
+
+	// rem - relative to root (base) font size
+	if strings.HasSuffix(value, "rem") {
+		numStr := strings.TrimSuffix(value, "rem")
+		if factor, err := strconv.ParseFloat(numStr, 64); err == nil && factor > 0 {
+			return factor * css.BaseFontHeight
+		}
+	}
+
+	// Not a relative value - return 0 to indicate no resolution needed
+	return 0
+}
+
 // expandShorthand expands CSS shorthand properties to their longhand equivalents.
 // CSS 2.1 §8.3, §8.4: Margin and padding shorthand expansion
 // CSS 2.1 §8.5: Border shorthand expansion
 // Supports 1-4 value patterns per CSS 2.1 specification
 func expandShorthand(property, value string) map[string]string {
 	result := make(map[string]string)
+
+	// Handle background shorthand - extract color when it's a simple color value
+	// CSS 2.1 §14.2.1: The background shorthand
+	if property == "background" {
+		if !strings.Contains(value, "url(") {
+			// Simple background color value (e.g., "background: #eaecf0")
+			// Also keep as "background" for backward compat with renderer
+			result["background-color"] = value
+			result["background"] = value
+			return result
+		}
+		result[property] = value
+		return result
+	}
 
 	// Handle border shorthand properties
 	// CSS 2.1 §8.5.4: The border shorthand property

--- a/style/style.go
+++ b/style/style.go
@@ -425,6 +425,40 @@ func resolveRelativeFontSize(value string, parentStyles map[string]string) float
 func expandShorthand(property, value string) map[string]string {
 	result := make(map[string]string)
 
+	// Handle font shorthand
+	// CSS 2.1 §15.8: font shorthand
+	if property == "font" {
+		if value == "inherit" {
+			// Just pass through - inheritance handles this
+			result[property] = value
+			return result
+		}
+		// Basic font shorthand parsing - extract font-size if present
+		parts := splitWhitespace(value)
+		for _, part := range parts {
+			if size := css.ParseFontSize(part); size > 0 {
+				result["font-size"] = part
+			} else if part == "bold" || part == "bolder" {
+				result["font-weight"] = part
+			} else if part == "italic" || part == "oblique" {
+				result["font-style"] = part
+			} else if part == "normal" {
+				// Skip - it's a reset value
+			}
+		}
+		if len(result) == 0 {
+			result[property] = value
+		}
+		return result
+	}
+
+	// Handle list-style shorthand
+	// CSS 2.1 §12.5: list-style shorthand
+	if property == "list-style" || property == "list-style-type" {
+		result[property] = value
+		return result
+	}
+
 	// Handle background shorthand - extract color when it's a simple color value
 	// CSS 2.1 §14.2.1: The background shorthand
 	if property == "background" {

--- a/style/useragent.go
+++ b/style/useragent.go
@@ -19,8 +19,14 @@ tr { display: table-row; }
 td, th { display: table-cell; padding: 1px; }
 
 /* CSS 2.1 §9.2.1: Block-level elements */
-div, p, h1, h2, h3, h4, h5, h6, ul, ol, li, dl, dt, dd, 
+div, p, h1, h2, h3, h4, h5, h6, ul, ol, li, dl, dt, dd,
 blockquote, pre, form, fieldset, hr, address, center {
+	display: block;
+}
+
+/* HTML5 §4.3-4.4: Semantic sectioning and grouping elements */
+section, article, nav, aside, header, footer, main,
+figure, figcaption, details, summary, dialog {
 	display: block;
 }
 

--- a/style/useragent.go
+++ b/style/useragent.go
@@ -60,6 +60,10 @@ code, kbd, samp, tt { font-family: monospace; }
 small { font-size: 0.83em; }
 big { font-size: 1.17em; }
 
+/* Superscript and subscript */
+sup { font-size: 0.75em; }
+sub { font-size: 0.75em; }
+
 /* Preformatted text */
 pre { font-family: monospace; white-space: pre; margin: 1em 0; }
 
@@ -72,8 +76,17 @@ input, textarea, select, button {
 	font-family: inherit;
 }
 
+/* Definition lists */
+dl { margin: 1em 0; }
+dt { font-weight: bold; }
+dd { margin-left: 40px; }
+
 /* Quotations */
 blockquote { margin: 1em 40px; }
+
+/* Figure */
+figure { margin: 1em 40px; }
+figcaption { font-size: 0.9em; }
 
 /* Center element - deprecated but still used */
 center { text-align: center; }

--- a/test/mobile-wikipedia-stress.html
+++ b/test/mobile-wikipedia-stress.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { font-size: 14px; margin: 0; padding: 8px; }
+.mw-heading { border-bottom: 1px solid #a2a9b1; margin-top: 1em; }
+.mw-heading h2 { font-size: 1.5em; font-weight: bold; }
+.mw-heading h3 { font-size: 1.17em; font-weight: bold; }
+.reference { font-size: 0.8em; vertical-align: super; }
+.reflist { font-size: 0.9em; }
+.infobox { border: 1px solid #a2a9b1; background-color: #f8f9fa; margin: 0 0 1em 1em; padding: 0.5em; }
+.infobox th { background-color: #ddd; padding: 4px; text-align: left; }
+.infobox td { padding: 4px; }
+.navbox { border: 1px solid #aaa; background-color: #fdfdfd; margin-top: 1em; }
+.navbox th { background-color: #ccf; padding: 2px 4px; text-align: center; }
+.toc { background-color: #f8f9fa; border: 1px solid #a2a9b1; padding: 0.5em; display: block; }
+.toc ul { margin: 0; padding-left: 1.5em; }
+.hatnote { font-style: italic; padding-left: 1.6em; margin-bottom: 0.5em; }
+.thumb { margin: 0.5em 0; padding: 3px; border: 1px solid #c8ccd1; background-color: #f8f9fa; }
+.thumbcaption { font-size: 0.9em; padding: 3px; }
+sup { font-size: 0.75em; }
+.mw-editsection { display: none; }
+.noprint { display: none; }
+code { background-color: #f4f4f4; padding: 1px 4px; font-family: monospace; }
+blockquote { margin: 1em 2em; padding-left: 1em; border-left: 3px solid #c8ccd1; }
+</style>
+</head>
+<body>
+<h1>Go (programming language)</h1>
+<div class="hatnote">For other uses, see <a href="#">Go (disambiguation)</a>.</div>
+
+<p><b>Go</b> is a <a href="#">statically typed</a>, <a href="#">compiled</a> <a href="#">programming language</a> designed at <a href="#">Google</a><sup class="reference">[1]</sup> by Robert Griesemer, Rob Pike, and Ken Thompson.<sup class="reference">[2]</sup> It is syntactically similar to <a href="#">C</a>, but also has memory safety, garbage collection, structural typing, and CSP-style <a href="#">concurrency</a>.<sup class="reference">[3]</sup></p>
+
+<div class="toc">
+<p><b>Contents</b></p>
+<ul>
+<li><a href="#">1 History</a></li>
+<li><a href="#">2 Design</a></li>
+<li><a href="#">3 Syntax</a>
+<ul>
+<li><a href="#">3.1 Types</a></li>
+<li><a href="#">3.2 Interface system</a></li>
+</ul>
+</li>
+<li><a href="#">4 Concurrency</a></li>
+</ul>
+</div>
+
+<table class="infobox">
+<tr><th colspan="2" style="text-align: center; background-color: #b0c4de;">Go</th></tr>
+<tr><th>Paradigm</th><td><a href="#">Multi-paradigm</a>: concurrent, functional, imperative, object-oriented</td></tr>
+<tr><th>Designed by</th><td>Robert Griesemer, Rob Pike, Ken Thompson</td></tr>
+<tr><th>Developer</th><td>The Go Authors</td></tr>
+<tr><th>First appeared</th><td>November 10, 2009</td></tr>
+<tr><th>Stable release</th><td>1.22.0 / February 6, 2024</td></tr>
+<tr><th>Typing</th><td>Static, strong, inferred, structural</td></tr>
+<tr><th>OS</th><td>Linux, macOS, Windows, FreeBSD, and others</td></tr>
+<tr><th>License</th><td>BSD-style + patent grant</td></tr>
+<tr><th>Website</th><td><a href="#">go.dev</a></td></tr>
+</table>
+
+<div class="mw-heading"><h2>History</h2></div>
+<p>Go was designed at Google in 2007 to improve programming productivity in an era of multicore, networked machines and large codebases. The designers wanted to address criticism of other languages in use at Google, but keep their useful characteristics:</p>
+<ul>
+<li>Static typing and run-time efficiency (like C)</li>
+<li>Readability and usability (like Python)</li>
+<li>High-performance networking and multiprocessing</li>
+</ul>
+
+<p>Its designers were primarily motivated by their shared dislike of <a href="#">C++</a>.<sup class="reference">[4]</sup></p>
+
+<blockquote>
+<p>"Go is an attempt to combine the ease of programming of an interpreted, dynamically typed language with the efficiency and safety of a statically typed, compiled language."</p>
+</blockquote>
+
+<div class="mw-heading"><h2>Syntax</h2></div>
+<p>Go's syntax includes changes from C aimed at keeping code concise and readable. A combined declaration/initialization operator was introduced that allows the programmer to write <code>i := 3</code> or <code>s := "Hello, world!"</code> without specifying the types of variables used.</p>
+
+<div class="mw-heading"><h3>Types</h3></div>
+<p>Go has a number of built-in types, including numeric ones (<code>byte</code>, <code>int64</code>, <code>float32</code>, etc.), booleans, and character strings (<code>string</code>). Strings are immutable; built-in operators and keywords provide concatenation, comparison, and UTF-8 encoding/decoding.</p>
+
+<div class="mw-heading"><h2>Concurrency</h2></div>
+<p>Go provides facilities for writing concurrent programs. Goroutines are lightweight processes (not operating system threads), and channels are typed conduits through which you can send and receive values. This was inspired by <a href="#">communicating sequential processes</a> (CSP).</p>
+
+<table class="navbox" style="border-collapse: collapse;">
+<tr><th colspan="2">Go programming language</th></tr>
+<tr><td>Implementations</td><td><a href="#">gc</a> | <a href="#">gccgo</a> | <a href="#">GopherJS</a> | <a href="#">TinyGo</a></td></tr>
+<tr><td>People</td><td><a href="#">Rob Pike</a> | <a href="#">Ken Thompson</a> | <a href="#">Robert Griesemer</a></td></tr>
+</table>
+
+<div class="noprint">This content should be hidden</div>
+
+<footer style="margin-top: 2em; padding-top: 1em; border-top: 1px solid #ccc; font-size: 0.85em; color: #666;">
+<p>This page was last edited on 15 March 2026. Text is available under the Creative Commons Attribution-ShareAlike License.</p>
+</footer>
+</body>
+</html>

--- a/test/mobile-wikipedia.html
+++ b/test/mobile-wikipedia.html
@@ -1,0 +1,422 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+<title>Go (programming language) - Wikipedia</title>
+<style>
+  /* Reset and base */
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.65em;
+    color: #202122;
+    background-color: #fff;
+    margin: 0;
+    padding: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  /* Header / chrome */
+  .header-container {
+    background-color: #fff;
+    border-bottom: 1px solid #c8ccd1;
+    padding: 0.5em 1em;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .header-container .site-title {
+    font-size: 1em;
+    font-weight: bold;
+    color: #000;
+    text-decoration: none;
+  }
+  .header-container .search-icon {
+    font-size: 1.2em;
+    color: #54595d;
+    cursor: pointer;
+  }
+
+  /* Main content area */
+  .mw-body {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 1em 2em 1em;
+  }
+  .mw-body-content {
+    line-height: 1.65em;
+    font-size: 0.875em;
+  }
+  .mw-content-ltr {
+    direction: ltr;
+  }
+  .mw-parser-output {
+    word-wrap: break-word;
+  }
+
+  /* Page title */
+  .mw-first-heading {
+    font-family: "Linux Libertine", Georgia, Times, serif;
+    font-size: 1.8em;
+    line-height: 1.2em;
+    margin: 0.5em 0 0.25em 0;
+    padding: 0;
+    border-bottom: 1px solid #a2a9b1;
+    color: #000;
+  }
+
+  /* Tagline */
+  .tagline {
+    display: none;
+    font-size: 0.8em;
+    color: #72777d;
+  }
+
+  /* Section headings */
+  .mw-parser-output h2 {
+    font-family: "Linux Libertine", Georgia, Times, serif;
+    font-size: 1.5em;
+    font-weight: normal;
+    border-bottom: 1px solid #a2a9b1;
+    margin-top: 1em;
+    margin-bottom: 0.25em;
+    padding-bottom: 0.15em;
+    color: #000;
+  }
+  .mw-parser-output h3 {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-top: 0.8em;
+    margin-bottom: 0.2em;
+    color: #000;
+  }
+
+  /* Paragraphs */
+  .mw-parser-output p {
+    margin: 0.5em 0;
+  }
+
+  /* Links */
+  .mw-parser-output a {
+    color: #3366cc;
+    text-decoration: none;
+  }
+  .mw-parser-output a:visited { color: #795cb2; }
+  .mw-parser-output a:hover { text-decoration: underline; }
+
+  /* Table of contents */
+  .toc {
+    background-color: #f8f9fa;
+    border: 1px solid #a2a9b1;
+    padding: 0.75em 1em;
+    margin: 0.5em 0 1em 0;
+    display: block;
+  }
+  .toc-title {
+    font-weight: bold;
+    text-align: center;
+    font-size: 1.1em;
+    margin-bottom: 0.5em;
+  }
+  .toc ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 1.5em;
+  }
+  .toc > ul { padding-left: 0; }
+  .toc li { margin: 0.2em 0; }
+  .toc a { color: #3366cc; text-decoration: none; }
+  .tocnumber { margin-right: 0.4em; color: #202122; }
+
+  /* Infobox */
+  .infobox {
+    border: 1px solid #a2a9b1;
+    border-collapse: collapse;
+    background-color: #f8f9fa;
+    width: 100%;
+    max-width: 320px;
+    margin: 0.5em 0 0.5em 1em;
+    padding: 0;
+    float: right;
+    clear: right;
+    font-size: 0.85em;
+    line-height: 1.5em;
+  }
+  .infobox caption,
+  .infobox .infobox-title {
+    background-color: #cce;
+    font-weight: bold;
+    text-align: center;
+    padding: 0.4em;
+    font-size: 1.1em;
+  }
+  .infobox td,
+  .infobox th {
+    border: 1px solid #a2a9b1;
+    padding: 0.35em 0.6em;
+    vertical-align: top;
+  }
+  .infobox th {
+    background-color: #e8e8e8;
+    text-align: left;
+    white-space: nowrap;
+  }
+  .infobox .infobox-image {
+    text-align: center;
+    padding: 0.6em;
+    background-color: #fff;
+  }
+  .infobox .infobox-image img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* Generic table styling */
+  .wikitable {
+    border-collapse: collapse;
+    margin: 1em 0;
+    background-color: #f8f9fa;
+    border: 1px solid #a2a9b1;
+    font-size: 0.9em;
+    width: 100%;
+  }
+  .wikitable th, .wikitable td {
+    border: 1px solid #a2a9b1;
+    padding: 0.4em 0.6em;
+    text-align: left;
+  }
+  .wikitable th {
+    background-color: #eaecf0;
+    font-weight: bold;
+  }
+
+  /* Lists */
+  .mw-parser-output ul {
+    margin: 0.3em 0 0.3em 1.6em;
+    padding: 0;
+  }
+  .mw-parser-output li { margin-bottom: 0.25em; }
+
+  /* Image placeholder */
+  .thumb {
+    border: 1px solid #c8ccd1;
+    background-color: #f8f9fa;
+    padding: 3px;
+    margin: 0.5em 0 0.5em 1em;
+    max-width: 220px;
+    float: right;
+    clear: right;
+    text-align: center;
+  }
+  .thumb .thumbinner {
+    font-size: 0.8em;
+    color: #54595d;
+  }
+  .thumb img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    background-color: #eee;
+  }
+  .thumbcaption { padding: 4px; line-height: 1.4em; }
+
+  /* Categories / footer */
+  .mw-footer {
+    border-top: 1px solid #c8ccd1;
+    margin-top: 2em;
+    padding: 1em;
+    font-size: 0.8em;
+    color: #72777d;
+    text-align: center;
+  }
+
+  /* Collapsible section toggle (mobile) */
+  .section-heading .mw-ui-icon { display: none; }
+  .mw-references-wrap { font-size: 0.85em; }
+  .reflist { list-style-type: decimal; }
+
+  /* Hatnote */
+  .hatnote {
+    font-style: italic;
+    padding-left: 1.6em;
+    margin-bottom: 0.5em;
+    color: #54595d;
+    font-size: 0.9em;
+  }
+
+  /* Short description (hidden on mobile) */
+  .shortdescription { display: none; }
+
+  /* Responsive adjustments */
+  @media screen and (max-width: 720px) {
+    .infobox {
+      float: none;
+      margin: 0.5em auto;
+      max-width: 100%;
+    }
+    .thumb {
+      float: none;
+      margin: 0.5em auto;
+      max-width: 100%;
+    }
+  }
+</style>
+</head>
+<body>
+  <header class="header-container">
+    <a href="#" class="site-title">Wikipedia</a>
+    <span class="search-icon">&#128269;</span>
+  </header>
+
+  <article class="mw-body" role="main">
+    <h1 class="mw-first-heading">Go (programming language)</h1>
+    <div class="tagline">From Wikipedia, the free encyclopedia</div>
+    <div class="shortdescription">Programming language designed at Google</div>
+
+    <div id="bodyContent" class="mw-body-content mw-content-ltr">
+      <div class="mw-parser-output">
+
+        <div class="hatnote">For other uses, see <a href="#">Go (disambiguation)</a>.</div>
+
+        <!-- Infobox -->
+        <table class="infobox">
+          <tr><td colspan="2" class="infobox-title">Go</td></tr>
+          <tr><td colspan="2" class="infobox-image">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='60'%3E%3Crect width='120' height='60' fill='%2300ADD8'/%3E%3Ctext x='60' y='38' text-anchor='middle' fill='white' font-size='24' font-family='Arial'%3EGo%3C/text%3E%3C/svg%3E" alt="Go Logo" width="120" height="60">
+          </td></tr>
+          <tr><th><a href="#">Paradigm</a></th><td><a href="#">Multi-paradigm</a>: <a href="#">concurrent</a>, <a href="#">functional</a>, <a href="#">imperative</a>, <a href="#">object-oriented</a></td></tr>
+          <tr><th>Designed&nbsp;by</th><td><a href="#">Robert Griesemer</a>, <a href="#">Rob Pike</a>, <a href="#">Ken Thompson</a></td></tr>
+          <tr><th>Developer</th><td>The Go Authors</td></tr>
+          <tr><th>First&nbsp;appeared</th><td>November 10, 2009</td></tr>
+          <tr><th><a href="#">Stable release</a></th><td>1.22.1 / March 5, 2024</td></tr>
+          <tr><th><a href="#">Typing</a></th><td><a href="#">Static</a>, <a href="#">strong</a>, <a href="#">inferred</a>, <a href="#">structural</a></td></tr>
+          <tr><th><a href="#">OS</a></th><td><a href="#">Linux</a>, <a href="#">macOS</a>, <a href="#">Windows</a>, <a href="#">FreeBSD</a>, and others</td></tr>
+          <tr><th><a href="#">License</a></th><td><a href="#">BSD-style</a> + patent grant</td></tr>
+          <tr><th>Website</th><td><a href="https://go.dev">go.dev</a></td></tr>
+        </table>
+
+        <!-- Lead section -->
+        <p><b>Go</b> is a <a href="#">statically typed</a>, <a href="#">compiled</a> <a href="#">high-level programming language</a> designed at <a href="#">Google</a> by <a href="#">Robert Griesemer</a>, <a href="#">Rob Pike</a>, and <a href="#">Ken Thompson</a>. It is syntactically similar to <a href="#">C</a>, but also has <a href="#">memory safety</a>, <a href="#">garbage collection</a>, <a href="#">structural typing</a>, and <a href="#">CSP</a>-style <a href="#">concurrency</a>. It is often referred to as <b>Golang</b> because of its former domain name, <code>golang.org</code>, but its proper name is <i>Go</i>.</p>
+
+        <p>There are two major implementations: Google's self-hosting <a href="#">toolchain</a>, targeting multiple <a href="#">operating systems</a> and <a href="#">WebAssembly</a>; and <a href="#">gccgo</a>, a <a href="#">GCC</a> frontend. A third-party source-to-source compiler, <a href="#">GopherJS</a>, compiles Go to <a href="#">JavaScript</a> for front-end <a href="#">web development</a>.</p>
+
+        <!-- Table of Contents -->
+        <nav class="toc" role="navigation">
+          <div class="toc-title">Contents</div>
+          <ul>
+            <li><span class="tocnumber">1</span> <a href="#History">History</a></li>
+            <li><span class="tocnumber">2</span> <a href="#Design">Design</a>
+              <ul>
+                <li><span class="tocnumber">2.1</span> <a href="#Syntax">Syntax</a></li>
+                <li><span class="tocnumber">2.2</span> <a href="#Types">Types</a></li>
+              </ul>
+            </li>
+            <li><span class="tocnumber">3</span> <a href="#Concurrency">Concurrency</a></li>
+            <li><span class="tocnumber">4</span> <a href="#Suitability">Suitability</a></li>
+            <li><span class="tocnumber">5</span> <a href="#Versions">Version history</a></li>
+            <li><span class="tocnumber">6</span> <a href="#See_also">See also</a></li>
+          </ul>
+        </nav>
+
+        <!-- History section -->
+        <section id="History">
+          <h2>History</h2>
+          <p>Go was designed at <a href="#">Google</a> in 2007 to improve programming productivity in an era of <a href="#">multicore processors</a>, networked machines, and large <a href="#">codebases</a>. The designers wanted to address criticism of other languages in use at Google, but keep their useful characteristics. The designers were primarily motivated by their shared dislike of <a href="#">C++</a>.</p>
+
+          <p>Go was publicly announced in November 2009, and version 1.0 was released in March 2012. Go is widely used in production at Google and in many other organizations and <a href="#">open-source</a> projects. In November 2016, the Go and Go Mono fonts were released by type designers <a href="#">Charles Bigelow</a> and <a href="#">Kris Holmes</a> specifically for use by the Go project.</p>
+
+          <div class="thumb">
+            <div class="thumbinner">
+              <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='120'%3E%3Crect width='200' height='120' fill='%23dde3e9'/%3E%3Ctext x='100' y='55' text-anchor='middle' fill='%23555' font-size='14' font-family='Arial'%3EGo mascot%3C/text%3E%3Ctext x='100' y='75' text-anchor='middle' fill='%23555' font-size='12' font-family='Arial'%3E(Gopher)%3C/text%3E%3C/svg%3E" alt="The Go gopher mascot" width="200" height="120">
+              <div class="thumbcaption">The Go gopher, the language's mascot, designed by <a href="#">Renee French</a>.</div>
+            </div>
+          </div>
+
+          <p>In August 2018, the Go principal contributors published two <i>draft designs</i> for new language features: <a href="#">generics</a> and <a href="#">error handling</a>, along with a change to the existing <a href="#">error</a> value semantics. Generics were eventually added in Go 1.18 in March 2022, representing the most significant change to the language since its initial release.</p>
+        </section>
+
+        <!-- Design section -->
+        <section id="Design">
+          <h2>Design</h2>
+          <p>Go is influenced by C, but with an emphasis on greater simplicity and safety. The language consists of:</p>
+
+          <ul>
+            <li>A syntax and environment adopting patterns more common in <a href="#">dynamic languages</a></li>
+            <li>Built-in concurrency primitives: lightweight <b>goroutines</b> and typed <b>channels</b></li>
+            <li>A fast compilation toolchain that uses a simple <a href="#">linking model</a></li>
+            <li>An interface system in place of <a href="#">virtual inheritance</a></li>
+            <li>A standard library with broad utility, including a built-in <a href="#">HTTP server</a></li>
+            <li>Automatic garbage collection for <a href="#">memory management</a></li>
+          </ul>
+
+          <p>Go deliberately omits certain features common in other languages, including <a href="#">inheritance</a>, <a href="#">assertions</a>, <a href="#">pointer arithmetic</a>, implicit <a href="#">type conversions</a>, <a href="#">tagged unions</a>, and <a href="#">exceptions</a>. The designers argue that these omissions make the language simpler and reduce sources of bugs.</p>
+
+          <h3 id="Syntax">Syntax</h3>
+          <p>Go's syntax includes changes from C aimed at keeping code concise and readable. A combined declaration/initialization operator (<code>:=</code>) was introduced to allow the compiler to <i>infer</i> the type of a variable. There is no need for semicolons as line terminators; they are added automatically by the compiler. Functions may return multiple values, which is used extensively in idiomatic Go to handle errors alongside normal return values.</p>
+
+          <h3 id="Types">Types</h3>
+          <p>Go has a number of built-in types, including numeric ones (<code>byte</code>, <code>int64</code>, <code>float32</code>, etc.), <code>bool</code>, and <code>string</code>. <a href="#">Strings</a> are immutable; built-in operators and keywords (rather than functions) provide concatenation, comparison, and <a href="#">UTF-8</a> encoding/decoding. Record types can be defined with the <code>struct</code> keyword.</p>
+        </section>
+
+        <!-- Concurrency section -->
+        <section id="Concurrency">
+          <h2>Concurrency</h2>
+          <p>Go provides facilities for writing concurrent programs. <b>Goroutines</b> are <a href="#">lightweight threads</a> managed by the Go runtime, started with the <code>go</code> keyword. <b>Channels</b> are typed conduits through which values can be sent and received, providing <a href="#">synchronization</a> without explicit locks or condition variables.</p>
+
+          <p>The <code>select</code> statement in Go allows a goroutine to wait on multiple communication operations. This model of concurrency is derived from <a href="#">Hoare's Communicating Sequential Processes</a> (CSP), and is considered one of Go's most distinctive and powerful features. Multiple goroutines can communicate efficiently through channels, enabling developers to build <i>highly concurrent</i> systems with relatively straightforward code.</p>
+        </section>
+
+        <!-- Suitability section -->
+        <section id="Suitability">
+          <h2>Suitability</h2>
+          <p>Go is used extensively for building:</p>
+          <ul>
+            <li><a href="#">Cloud infrastructure</a> tools (e.g., <a href="#">Docker</a>, <a href="#">Kubernetes</a>)</li>
+            <li>Command-line interfaces and developer tools</li>
+            <li><a href="#">Microservices</a> and <a href="#">API</a> servers</li>
+            <li>Distributed systems and databases</li>
+            <li>Network servers and <a href="#">web applications</a></li>
+          </ul>
+          <p>Notable projects written in Go include <a href="#">Docker</a>, <a href="#">Kubernetes</a>, <a href="#">Terraform</a>, <a href="#">etcd</a>, <a href="#">CockroachDB</a>, and the <a href="#">Hugo</a> static site generator.</p>
+        </section>
+
+        <!-- Version history section -->
+        <section id="Versions">
+          <h2>Version history</h2>
+          <table class="wikitable">
+            <tr><th>Version</th><th>Release date</th><th>Key features</th></tr>
+            <tr><td>1.0</td><td>March 2012</td><td>Initial stable release</td></tr>
+            <tr><td>1.5</td><td>August 2015</td><td>Concurrent garbage collector; shared libraries</td></tr>
+            <tr><td>1.11</td><td>August 2018</td><td><a href="#">Go modules</a> (preliminary support)</td></tr>
+            <tr><td>1.13</td><td>September 2019</td><td>Number literal improvements; TLS 1.3 by default</td></tr>
+            <tr><td>1.16</td><td>February 2021</td><td>Modules on by default; <code>embed</code> package</td></tr>
+            <tr><td>1.18</td><td>March 2022</td><td><b>Generics</b>; fuzzing support; workspaces</td></tr>
+            <tr><td>1.21</td><td>August 2023</td><td>Built-in functions <code>min</code>, <code>max</code>, <code>clear</code></td></tr>
+            <tr><td>1.22</td><td>February 2024</td><td>Rangefunc iterators; improved routing</td></tr>
+          </table>
+        </section>
+
+        <!-- See also section -->
+        <section id="See_also">
+          <h2>See also</h2>
+          <ul>
+            <li><a href="#">Comparison of programming languages</a></li>
+            <li><a href="#">Rust (programming language)</a></li>
+            <li><a href="#">Dart (programming language)</a></li>
+            <li><a href="#">Crystal (programming language)</a></li>
+          </ul>
+        </section>
+
+      </div>
+    </div>
+  </article>
+
+  <footer class="mw-footer" role="contentinfo">
+    <p>Content is available under <a href="#" style="color:#3366cc;">CC BY-SA 4.0</a> unless otherwise noted.</p>
+    <p>Privacy policy &middot; About Wikipedia &middot; Disclaimers</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Comprehensive improvements to render mobile Wikipedia pages well at narrow viewport widths (375px). This touches the full rendering pipeline: CSS parsing, style computation, layout, and rendering.

### CSS Parser & Values
- **`rgb()`/`rgba()` color functions**: Parse comma and space-separated syntax with percentage and numeric alpha values
- **`!important` declarations**: Properly parsed and applied with correct cascade priority
- **Universal selector (`*`)**: Tokenizer and selector matching support
- **Child combinator (`>`)**: Graceful handling (treated as descendant for now)
- **Parser error recovery**: `skipToNextRule()` prevents infinite loops on unrecognized syntax

### Style & Cascade
- **Relative font-size resolution**: `em`, `rem`, `%` units resolved against parent computed font-size
- **Background shorthand expansion**: Simple color values expanded to `background-color`
- **Font shorthand**: Basic parsing for font shorthand property
- **Universal selector matching**: `*` matches any element in style computation

### Layout Engine
- **Text wrapping at word boundaries**: `wrapText()` function breaks text to fit narrow viewports
- **Inline formatting context**: Complete rewrite of `layoutInlineChildren` with line tracking
- **Margin collapsing**: Adjacent block margins collapse per CSS 2.1 §8.3.1
- **Negative margins**: Supported for Wikipedia's layout tricks
- **`max-width`/`min-width`**: Constrain block widths
- **`line-height`**: Resolved for proper line spacing
- **`em`/`rem`/`pt`/`vw` units**: In `parseLengthWithFont()`
- **Table column scaling**: Columns scale proportionally when content exceeds table width
- **`border-collapse: collapse`**: Sets border-spacing to 0
- **HTML5 semantic elements**: `section`, `article`, `nav`, `aside`, `header`, `footer`, `main`, etc. as block-level
- **`<br>` handling**: Treated as block-level for line breaks
- **`hidden` attribute**: Elements with HTML `hidden` attribute get `display: none`

### Rendering
- **Wrapped text rendering**: Renders pre-computed wrapped lines with proper Y offsets
- **`text-align` for wrapped text**: Center/right alignment using container width reference
- **List markers**: Bullet markers rendered for `<li>` elements

### User-Agent Stylesheet
- HTML5 semantic elements as block display
- `sup`/`sub` font-size defaults
- Definition list (`dl`/`dt`/`dd`) styles
- `figure`/`figcaption` styles

### Infrastructure
- **User-Agent header**: Added to HTTP requests (both main fetch and resource loading)
- **Test pages**: `test/mobile-wikipedia.html` and `test/mobile-wikipedia-stress.html` for visual verification

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] 35/39 WPT CSS reftests pass (89.7%) — 4 failures are pre-existing/expected
- [x] Visual verification with mobile Wikipedia test pages at 375px width
- [x] Stress test with infobox, TOC, blockquotes, code blocks, citations, navbox

https://claude.ai/code/session_01RfQPuawrmUGVuL3cQnvsww